### PR TITLE
Adding integration tests, adjusting signatures, placeholder for ByteArray traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kybe-rs"
 version = "0.1.0"
-authors =  ["Stanislas Plessia <stplessia@gmail.com>"]
+authors =  ["Stanislas Plessia <stplessia@gmail.com>", "Remi Geraud-Stewart"]
 edition = "2018"
 description = "Implementation of the key encapsulation mechanism (KEM) and public-key encryption (PKE) schemes of CRYSTALS-KYBER"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,21 @@ mod vector;
 use self::vector::{Dot, Vector};
 
 pub struct Poly {}
+#[derive(Debug)]
 pub struct ByteArray {}
+
+impl ByteArray {
+    pub fn random() -> Self {
+        unimplemented!()
+    }
+}
+
+impl PartialEq for ByteArray {
+    fn eq(&self, other: &Self) -> bool {
+        unimplemented!()
+    }
+}
+impl Eq for ByteArray {}
 
 ////////////// PKE /////////////////////////
 
@@ -14,12 +28,12 @@ pub fn kyber_cpapke_key_gen() -> (ByteArray, ByteArray) {
 }
 
 // Encryption : public key, message, random coins => ciphertext
-pub fn kyber_cpapke_enc(pk: ByteArray, m: ByteArray, r: ByteArray) -> ByteArray {
+pub fn kyber_cpapke_enc(pk: &ByteArray, m: &ByteArray, r: ByteArray) -> ByteArray {
     unimplemented!();
 }
 
 // Decryption : secret key, ciphertext => message
-pub fn kyber_cpapke_dec(sk: ByteArray, c: ByteArray) -> ByteArray {
+pub fn kyber_cpapke_dec(sk: &ByteArray, c: &ByteArray) -> ByteArray {
     unimplemented!();
 }
 
@@ -31,12 +45,12 @@ pub fn kyber_ccakem_key_gen() -> (ByteArray, ByteArray) {
 }
 
 // Encryption : public key  => ciphertext, Shared Key
-pub fn kyber_ccakem_enc(pk: ByteArray) -> (ByteArray, ByteArray) {
+pub fn kyber_ccakem_enc(pk: &ByteArray) -> (ByteArray, ByteArray) {
     unimplemented!();
 }
 
 // Decryption : secret key, ciphertext => Shared Key
-pub fn kyber_ccakem_dec(c: ByteArray, sk: ByteArray) -> ByteArray {
+pub fn kyber_ccakem_dec(c: &ByteArray, sk: &ByteArray) -> ByteArray {
     unimplemented!();
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,32 @@
+use kybe_rs;
+
+#[test]
+fn pke_keygen_call() {
+    kybe_rs::kyber_cpapke_key_gen();
+}
+
+#[test]
+fn encrypt_then_decrypt() {
+    let (sk, pk) = kybe_rs::kyber_cpapke_key_gen();
+
+    let m = kybe_rs::ByteArray::random();
+    let r = kybe_rs::ByteArray::random();
+
+    let enc = kybe_rs::kyber_cpapke_enc(&pk, &m, r);
+    let dec = kybe_rs::kyber_cpapke_dec(&sk, &enc);
+
+    assert_eq!(m, dec);
+}
+
+#[test]
+fn kem_keygen_call() {
+    kybe_rs::kyber_ccakem_key_gen();
+}
+
+#[test]
+fn encapsulate_then_decapsulate() {
+    let (sk, pk) = kybe_rs::kyber_ccakem_key_gen();
+    let (ctx, shk) = kybe_rs::kyber_ccakem_enc(&pk);
+    let shk2 = kybe_rs::kyber_ccakem_dec(&ctx, &sk);
+    assert_eq!(shk, shk2);
+}


### PR DESCRIPTION
Basic integration tests for the KEM and the PKE.

The signature for high-level APIs was adjusted as we may not want to borrow (and consume the variable) every time we call them, except (possibly) in the case of r.

A basic skeleton for ByteArray's equality trait was defined, so that assert_eq! can have something to work with.