### PR TITLE
Fix SHAKE, minor fixes on polynomials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ categories = ["cryptography", "science"]
 repository = "https://github.com/rust-crypto-labs/kybe-rs"
 
 [dependencies]
-sha3 = "0.9.1"
+sha3 = "0.8.0"
+digest = "0.9.0"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,21 +1,41 @@
-use sha3::{Digest, Sha3_256, Sha3_512, Shake128, Shake256};
+use crate::sha3::digest::ExtendableOutput;
+use crate::sha3::digest::XofReader;
+use crate::sha3::Digest;
 
-pub fn shake_128(_d: Vec<u8>) -> Vec<u8> {
+use sha3::{Sha3XofReader, Sha3_256, Sha3_512, Shake128, Shake256};
+
+pub fn shake_128(data: Vec<u8>, len: usize) -> Vec<u8> {
     unimplemented!();
+    use crate::sha3::digest::Input;
+    let mut buffer = vec![0; len];
+    let mut shake: Shake128 = Default::default();
+    shake.input(data);
+
+    let mut reader = shake.xof_result();
+    reader.read(&mut buffer);
+    buffer
 }
 
-pub fn shake_256(_d: Vec<u8>) -> Vec<u8> {
-    unimplemented!();
+pub fn shake_256(data: Vec<u8>, len: usize) -> Vec<u8> {
+    //unimplemented!();
+    use crate::sha3::digest::Input;
+    let mut buffer = vec![0; len];
+    let mut shake: Shake256 = Default::default();
+    shake.input(data);
+
+    let mut reader = shake.xof_result();
+    reader.read(&mut buffer);
+    buffer
 }
 
-pub fn sha3_256(d: Vec<u8>) -> Vec<u8> {
-    let mut hasher = Sha3_256::new();
-    hasher.update(d);
-    hasher.finalize().to_vec()
+pub fn sha3_256(data: Vec<u8>) -> Vec<u8> {
+    let mut hasher: Sha3_256 = Default::default();
+    hasher.input(data);
+    hasher.result().to_vec()
 }
 
-pub fn sha3_512(d: Vec<u8>) -> Vec<u8> {
-    let mut hasher = Sha3_512::new();
-    hasher.update(d);
-    hasher.finalize().to_vec()
+pub fn sha3_512(data: Vec<u8>) -> Vec<u8> {
+    let mut hasher: Sha3_512 = Default::default();
+    hasher.input(data);
+    hasher.result().to_vec()
 }

--- a/src/polyvec/ff.rs
+++ b/src/polyvec/ff.rs
@@ -8,7 +8,7 @@ pub trait FiniteField: Sized + FiniteRing {
 }
 
 // Finite Ring element
-pub trait FiniteRing: Sized {
+pub trait FiniteRing: Sized + Eq {
     /// Check if the element is the additive identity of the field
     fn is_zero(&self) -> bool;
 
@@ -32,9 +32,6 @@ pub trait FiniteRing: Sized {
 
     /// Defines the multiplication of two elements
     fn mul(&self, other: &Self) -> Self;
-
-    /// Checks if two elements are equal
-    fn equals(&self, other: &Self) -> bool;
 
     /// Converts the element to a bytes representation
     fn into_bytes(self) -> Vec<u8>;

--- a/src/polyvec/mod.rs
+++ b/src/polyvec/mod.rs
@@ -71,10 +71,6 @@ impl FiniteRing for PrimeField3329 {
         }
     }
 
-    fn equals(&self, other: &Self) -> bool {
-        self.sub(&other).is_zero()
-    }
-
     fn into_bytes(self) -> Vec<u8> {
         unimplemented!()
     }
@@ -93,3 +89,11 @@ impl FiniteField for PrimeField3329 {
         Ok(self.mul(&other.inv()?))
     }
 }
+
+impl PartialEq for PrimeField3329 {
+    fn eq(&self, other: &Self) -> bool {
+        self.val == other.val
+    }
+}
+
+impl Eq for PrimeField3329 {}

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -12,7 +12,7 @@ where
     T: FiniteField + Clone,
 {
     fn is_zero(&self) -> bool {
-        self.equals(&Self::zero())
+        self.eq(&Self::zero())
     }
 
     fn dimension() -> usize {
@@ -45,8 +45,22 @@ where
         }
     }
 
-    fn add(&self, _other: &Self) -> Self {
-        unimplemented!()
+    fn add(&self, other: &Self) -> Self {
+        let mut degree = self.degree().max(other.degree);
+        let mut coefficients = vec![T::zero(); degree];
+        for (i, c) in self.coefficients.iter().enumerate() {
+            coefficients[i] = other.coefficients[i].add(c);
+        }
+
+        // Diminish degree if leading coefficient is zero
+        while degree > 0 && coefficients[degree - 1].eq(&T::zero()) {
+            degree -= 1;
+        }
+
+        Self {
+            coefficients,
+            degree,
+        }
     }
 
     fn sub(&self, other: &Self) -> Self {
@@ -58,10 +72,6 @@ where
         unimplemented!()
     }
 
-    fn equals(&self, _other: &Self) -> bool {
-        unimplemented!()
-    }
-
     fn into_bytes(self) -> Vec<u8> {
         unimplemented!()
     }
@@ -70,6 +80,25 @@ where
         unimplemented!()
     }
 }
+impl<T> PartialEq for Polynomial<T>
+where
+    T: FiniteField,
+{
+    fn eq(&self, other: &Self) -> bool {
+        if self.degree != other.degree {
+            return false;
+        }
+
+        for (i, c) in self.coefficients.iter().enumerate() {
+            if !c.eq(&other.coefficients[i]) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<T> Eq for Polynomial<T> where T: FiniteField {}
 
 impl<T> Polynomial<T>
 where

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,13 +2,13 @@ use kybe_rs;
 
 #[test]
 fn pke_keygen_call() {
-    let params = (2,0,0);
+    let params = (2, 0, 0);
     kybe_rs::kyber_cpapke_key_gen(params);
 }
 
 #[test]
 fn encrypt_then_decrypt() {
-    let params = (2,0,0);
+    let params = (2, 0, 0);
     let (sk, pk) = kybe_rs::kyber_cpapke_key_gen(params);
 
     let m = kybe_rs::ByteArray::random();


### PR DESCRIPTION
It was necessary to downgrade the sha3 crate version (because Shake is not yet implemented/not usable on the latest 0.9 version). In the time being 0.8 seems sufficient and provides everything we need.

Rather than an equal() function in the Polynomial and FiniteField trait, the Eq trait was added.