### PR TITLE
Move to const generics

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -40,7 +40,7 @@ pub fn decompress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Po
 }
 
 /// Compress function on R_q^k
-pub fn compress_polyvec<const N: usize>(x: PolyVec3329<N>, d: usize, q: usize) -> PolyVec3329<N> {
+pub fn compress_polyvec<const N: usize, const D: usize>(x: PolyVec3329<N,D>, d: usize, q: usize) -> PolyVec3329<N,D> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(compress_poly(xi.clone(), d, q));
@@ -49,7 +49,7 @@ pub fn compress_polyvec<const N: usize>(x: PolyVec3329<N>, d: usize, q: usize) -
 }
 
 /// Decompress function on R_q^k
-pub fn decompress_polyvec<const N: usize>(x: PolyVec3329<N>, d: usize, q: usize) -> PolyVec3329<N> {
+pub fn decompress_polyvec<const N: usize, const D: usize>(x: PolyVec3329<N,D>, d: usize, q: usize) -> PolyVec3329<N,D> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(decompress_poly(xi.clone(), d, q));

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -27,7 +27,7 @@ pub fn compress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Poly
     for xi in x.coefficients.iter() {
         coeffs.push(F3329::from_int(compress_integer(xi.to_int(), d, q)));
     }
-    Poly3329::from_vec(coeffs, x.dimension())
+    Poly3329::from_vec(coeffs, N)
 }
 
 /// Deompress function on R_q
@@ -36,11 +36,15 @@ pub fn decompress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Po
     for xi in x.coefficients.iter() {
         coeffs.push(F3329::from_int(decompress_integer(xi.to_int(), d, q)));
     }
-    Poly3329::from_vec(coeffs, x.dimension())
+    Poly3329::from_vec(coeffs, N)
 }
 
 /// Compress function on R_q^k
-pub fn compress_polyvec<const N: usize, const D: usize>(x: PolyVec3329<N,D>, d: usize, q: usize) -> PolyVec3329<N,D> {
+pub fn compress_polyvec<const N: usize, const D: usize>(
+    x: PolyVec3329<N, D>,
+    d: usize,
+    q: usize,
+) -> PolyVec3329<N, D> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(compress_poly(xi.clone(), d, q));
@@ -49,7 +53,11 @@ pub fn compress_polyvec<const N: usize, const D: usize>(x: PolyVec3329<N,D>, d: 
 }
 
 /// Decompress function on R_q^k
-pub fn decompress_polyvec<const N: usize, const D: usize>(x: PolyVec3329<N,D>, d: usize, q: usize) -> PolyVec3329<N,D> {
+pub fn decompress_polyvec<const N: usize, const D: usize>(
+    x: PolyVec3329<N, D>,
+    d: usize,
+    q: usize,
+) -> PolyVec3329<N, D> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(decompress_poly(xi.clone(), d, q));

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -22,7 +22,7 @@ pub fn decompress_integer(x: usize, d: usize, q: usize) -> usize {
 }
 
 /// Compress function on R_q
-pub fn compress_poly(x: Poly3329, d: usize, q: usize) -> Poly3329 {
+pub fn compress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Poly3329<N> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(F3329::from_int(compress_integer(xi.to_int(), d, q)));
@@ -31,7 +31,7 @@ pub fn compress_poly(x: Poly3329, d: usize, q: usize) -> Poly3329 {
 }
 
 /// Deompress function on R_q
-pub fn decompress_poly(x: Poly3329, d: usize, q: usize) -> Poly3329 {
+pub fn decompress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Poly3329<N> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(F3329::from_int(decompress_integer(xi.to_int(), d, q)));
@@ -40,7 +40,7 @@ pub fn decompress_poly(x: Poly3329, d: usize, q: usize) -> Poly3329 {
 }
 
 /// Compress function on R_q^k
-pub fn compress_polyvec(x: PolyVec3329, d: usize, q: usize) -> PolyVec3329 {
+pub fn compress_polyvec<const N: usize>(x: PolyVec3329<N>, d: usize, q: usize) -> PolyVec3329<N> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(compress_poly(xi.clone(), d, q));
@@ -49,7 +49,7 @@ pub fn compress_polyvec(x: PolyVec3329, d: usize, q: usize) -> PolyVec3329 {
 }
 
 /// Decompress function on R_q^k
-pub fn decompress_polyvec(x: PolyVec3329, d: usize, q: usize) -> PolyVec3329 {
+pub fn decompress_polyvec<const N: usize>(x: PolyVec3329<N>, d: usize, q: usize) -> PolyVec3329<N> {
     let mut coeffs = vec![];
     for xi in x.coefficients.iter() {
         coeffs.push(decompress_poly(xi.clone(), d, q));

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -23,18 +23,18 @@ pub fn decompress_integer(x: usize, d: usize, q: usize) -> usize {
 
 /// Compress function on R_q
 pub fn compress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Poly3329<N> {
-    let mut coeffs = vec![];
-    for xi in x.coefficients.iter() {
-        coeffs.push(F3329::from_int(compress_integer(xi.to_int(), d, q)));
+    let mut coeffs = [Default::default(); N];
+    for i in 0..N {
+        coeffs[i] = F3329::from_int(compress_integer(x[i].to_int(), d, q));
     }
     Poly3329::from_vec(coeffs)
 }
 
 /// Deompress function on R_q
 pub fn decompress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Poly3329<N> {
-    let mut coeffs = vec![];
-    for xi in x.coefficients.iter() {
-        coeffs.push(F3329::from_int(decompress_integer(xi.to_int(), d, q)));
+    let mut coeffs = [Default::default(); N];
+    for i in 0..N {
+        coeffs[i] = F3329::from_int(decompress_integer(x[i].to_int(), d, q));
     }
     Poly3329::from_vec(coeffs)
 }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -27,7 +27,7 @@ pub fn compress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Poly
     for xi in x.coefficients.iter() {
         coeffs.push(F3329::from_int(compress_integer(xi.to_int(), d, q)));
     }
-    Poly3329::from_vec(coeffs, N)
+    Poly3329::from_vec(coeffs)
 }
 
 /// Deompress function on R_q
@@ -36,7 +36,7 @@ pub fn decompress_poly<const N: usize>(x: Poly3329<N>, d: usize, q: usize) -> Po
     for xi in x.coefficients.iter() {
         coeffs.push(F3329::from_int(decompress_integer(xi.to_int(), d, q)));
     }
-    Poly3329::from_vec(coeffs, N)
+    Poly3329::from_vec(coeffs)
 }
 
 /// Compress function on R_q^k

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -45,9 +45,9 @@ pub fn compress_polyvec<const N: usize, const D: usize>(
     d: usize,
     q: usize,
 ) -> PolyVec3329<N, D> {
-    let mut coeffs = vec![];
-    for xi in x.coefficients.iter() {
-        coeffs.push(compress_poly(xi.clone(), d, q));
+    let mut coeffs = [Default::default(); D];
+    for i in 0..D {
+        coeffs[i] = compress_poly(x.coefficients[i], d, q);
     }
     PolyVec3329::from_vec(coeffs)
 }
@@ -58,9 +58,9 @@ pub fn decompress_polyvec<const N: usize, const D: usize>(
     d: usize,
     q: usize,
 ) -> PolyVec3329<N, D> {
-    let mut coeffs = vec![];
-    for xi in x.coefficients.iter() {
-        coeffs.push(decompress_poly(xi.clone(), d, q));
+    let mut coeffs = [Default::default(); D];
+    for i in 0..D {
+        coeffs[i] = decompress_poly(x.coefficients[i], d, q);
     }
     PolyVec3329::from_vec(coeffs)
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -53,9 +53,9 @@ pub fn decode_to_polyvec<const N: usize, const D: usize>(
 ) -> PolyVec3329<N, D> {
     let k = bs.data.len() / (32 * ell);
     let mut b = bs;
-    let mut p_vec = PolyVec3329::from_vec(vec![Poly3329::init(); k]);
+    let mut p_vec = PolyVec3329::from_vec([Poly3329::init(); D]);
 
-    for i in 0..k {
+    for i in 0..D {
         let (a, c) = b.split_at(32 * ell);
         p_vec.set(i, decode_to_poly(a, ell));
         b = c.clone();

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -47,10 +47,13 @@ pub fn encode_poly<const N: usize>(p: Poly3329<N>, ell: usize) -> ByteArray {
 }
 
 /// Deserialize ByteArray into PolyVec
-pub fn decode_to_polyvec<const N: usize,const D: usize>(bs: ByteArray, ell: usize) -> PolyVec3329<N, D> {
+pub fn decode_to_polyvec<const N: usize, const D: usize>(
+    bs: ByteArray,
+    ell: usize,
+) -> PolyVec3329<N, D> {
     let k = bs.data.len() / (32 * ell);
     let mut b = bs;
-    let mut p_vec = PolyVec3329::from_vec(vec![Poly3329::init(256); k]);
+    let mut p_vec = PolyVec3329::from_vec(vec![Poly3329::init(); k]);
 
     for i in 0..k {
         let (a, c) = b.split_at(32 * ell);
@@ -62,11 +65,13 @@ pub fn decode_to_polyvec<const N: usize,const D: usize>(bs: ByteArray, ell: usiz
 }
 
 /// Serialize PolyVec into ByteArray
-pub fn encode_polyvec<const N: usize, const D: usize>(p_vec: PolyVec3329<N,D>, s: usize) -> ByteArray {
+pub fn encode_polyvec<const N: usize, const D: usize>(
+    p_vec: PolyVec3329<N, D>,
+    s: usize,
+) -> ByteArray {
     let mut b = ByteArray::new();
-    let ell = p_vec.dimension();
 
-    for i in 0..ell {
+    for i in 0..D {
         let p = p_vec.get(i);
         b = b.append(&encode_poly(p, s));
     }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -19,7 +19,7 @@ pub fn decode_to_poly<const N: usize>(bs: ByteArray, ell: usize) -> Poly3329<N> 
             }
         }
     }
-    Poly3329::from_vec(f, 256)
+    Poly3329::from_vec(f)
 }
 
 /// Serialize Poly into ByteArray

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -47,7 +47,7 @@ pub fn encode_poly<const N: usize>(p: Poly3329<N>, ell: usize) -> ByteArray {
 }
 
 /// Deserialize ByteArray into PolyVec
-pub fn decode_to_polyvec<const N: usize>(bs: ByteArray, ell: usize) -> PolyVec3329<N> {
+pub fn decode_to_polyvec<const N: usize,const D: usize>(bs: ByteArray, ell: usize) -> PolyVec3329<N, D> {
     let k = bs.data.len() / (32 * ell);
     let mut b = bs;
     let mut p_vec = PolyVec3329::from_vec(vec![Poly3329::init(256); k]);
@@ -62,7 +62,7 @@ pub fn decode_to_polyvec<const N: usize>(bs: ByteArray, ell: usize) -> PolyVec33
 }
 
 /// Serialize PolyVec into ByteArray
-pub fn encode_polyvec<const N: usize>(p_vec: PolyVec3329<N>, s: usize) -> ByteArray {
+pub fn encode_polyvec<const N: usize, const D: usize>(p_vec: PolyVec3329<N,D>, s: usize) -> ByteArray {
     let mut b = ByteArray::new();
     let ell = p_vec.dimension();
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -10,9 +10,9 @@ use crate::{
 /// Deserialize ByteArray into Polynomial
 /// Algorithm 3 p. 8
 pub fn decode_to_poly<const N: usize>(bs: ByteArray, ell: usize) -> Poly3329<N> {
-    let mut f = vec![F3329::from_int(0); 256];
+    let mut f = [F3329::zero(); N];
 
-    for i in 0..256 {
+    for i in 0..N {
         for j in 0..ell {
             if bs.get_bit(i * ell + j) {
                 f[i] = f[i].add(&F3329::from_int(1 << j));

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Deserialize ByteArray into Polynomial
 /// Algorithm 3 p. 8
-pub fn decode_to_poly(bs: ByteArray, ell: usize) -> Poly3329 {
+pub fn decode_to_poly<const N: usize>(bs: ByteArray, ell: usize) -> Poly3329<N> {
     let mut f = vec![F3329::from_int(0); 256];
 
     for i in 0..256 {
@@ -23,7 +23,7 @@ pub fn decode_to_poly(bs: ByteArray, ell: usize) -> Poly3329 {
 }
 
 /// Serialize Poly into ByteArray
-pub fn encode_poly(p: Poly3329, ell: usize) -> ByteArray {
+pub fn encode_poly<const N: usize>(p: Poly3329<N>, ell: usize) -> ByteArray {
     let mut b = vec![];
     let mut c: u8 = 0;
 
@@ -47,7 +47,7 @@ pub fn encode_poly(p: Poly3329, ell: usize) -> ByteArray {
 }
 
 /// Deserialize ByteArray into PolyVec
-pub fn decode_to_polyvec(bs: ByteArray, ell: usize) -> PolyVec3329 {
+pub fn decode_to_polyvec<const N: usize>(bs: ByteArray, ell: usize) -> PolyVec3329<N> {
     let k = bs.data.len() / (32 * ell);
     let mut b = bs;
     let mut p_vec = PolyVec3329::from_vec(vec![Poly3329::init(256); k]);
@@ -62,7 +62,7 @@ pub fn decode_to_polyvec(bs: ByteArray, ell: usize) -> PolyVec3329 {
 }
 
 /// Serialize PolyVec into ByteArray
-pub fn encode_polyvec(p_vec: PolyVec3329, s: usize) -> ByteArray {
+pub fn encode_polyvec<const N: usize>(p_vec: PolyVec3329<N>, s: usize) -> ByteArray {
     let mut b = ByteArray::new();
     let ell = p_vec.dimension();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn kyber_cpapke_key_gen(params: KyberParams) -> (ByteArray, ByteArray) {
         }
     }
 
-    let (mut s, mut e) = (PolyVec3329::<256,2>::init(k), PolyVec3329::<256,2>::init(k));
+    let (mut s, mut e) = (PolyVec3329::<256,2>::init(), PolyVec3329::<256,2>::init());
     let prf_len = 64 * params.eta;
 
     for i in 0..k {
@@ -119,7 +119,7 @@ pub fn kyber_cpapke_enc(
         }
     }
 
-    let (mut r_bold, mut e1) = (PolyVec3329::<256,2>::init(params.k), PolyVec3329::<256,2>::init(params.k));
+    let (mut r_bold, mut e1) = (PolyVec3329::<256,2>::init(), PolyVec3329::<256,2>::init());
     for i in 0..params.k {
         r_bold.set(i, cbd(prf(&r, i, prf_len), params.eta));
         e1.set(i, cbd(prf(&r, params.k + i, prf_len), params.eta));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub type F3329 = PrimeField3329;
 pub type Poly3329<const N: usize> = Polynomial<F3329, N>;
 
 /// Polynomial vector R_q^k
-pub type PolyVec3329<const N: usize, const D: usize> = PolyVec<Poly3329<N>,D>;
+pub type PolyVec3329<const N: usize, const D: usize> = PolyVec<Poly3329<N>, D>;
 
 /// Polynomial matrix R_q^(k*k)
 pub type PolyMatrix3329<const N: usize, const X: usize, const Y: usize> = Matrix<Poly3329<N>, X, Y>;
@@ -76,11 +76,11 @@ pub fn kyber_cpapke_key_gen(params: KyberParams) -> (ByteArray, ByteArray) {
 
     for i in 0..k {
         for j in 0..k {
-            a.set(i, j, parse(&xof(&rho, j, i, XOF_LEN), params.n, params.q));
+            a.set(i, j, parse(&xof(&rho, j, i, XOF_LEN), params.q));
         }
     }
 
-    let (mut s, mut e) = (PolyVec3329::<256,2>::init(), PolyVec3329::<256,2>::init());
+    let (mut s, mut e) = (PolyVec3329::<256, 2>::init(), PolyVec3329::<256, 2>::init());
     let prf_len = 64 * params.eta;
 
     for i in 0..k {
@@ -115,11 +115,11 @@ pub fn kyber_cpapke_enc(
 
     for i in 0..params.k {
         for j in 0..params.k {
-            a_t.set(i, j, parse(&xof(&rho, i, j, XOF_LEN), params.n, params.q));
+            a_t.set(i, j, parse(&xof(&rho, i, j, XOF_LEN), params.q));
         }
     }
 
-    let (mut r_bold, mut e1) = (PolyVec3329::<256,2>::init(), PolyVec3329::<256,2>::init());
+    let (mut r_bold, mut e1) = (PolyVec3329::<256, 2>::init(), PolyVec3329::<256, 2>::init());
     for i in 0..params.k {
         r_bold.set(i, cbd(prf(&r, i, prf_len), params.eta));
         e1.set(i, cbd(prf(&r, params.k + i, prf_len), params.eta));
@@ -131,7 +131,11 @@ pub fn kyber_cpapke_enc(
 
     let v = ntt_product_vec(&t_hat, &r_hat)
         .add(&e2)
-        .add(&decompress_poly(decode_to_poly::<256>(m.clone(), 1), 1, params.q));
+        .add(&decompress_poly(
+            decode_to_poly::<256>(m.clone(), 1),
+            1,
+            params.q,
+        ));
 
     let c1 = encode_polyvec(compress_polyvec(u_bold, params.du, params.q), params.du);
     let c2 = encode_poly(compress_poly(v, params.dv, params.q), params.dv);
@@ -145,7 +149,11 @@ pub fn kyber_cpapke_dec(params: KyberParams, sk: &ByteArray, c: &ByteArray) -> B
     let offset = params.du * params.k * params.n / 8;
     let (c1, c2) = c.split_at(offset);
 
-    let u = decompress_polyvec(decode_to_polyvec::<256,2>(c1, params.du), params.du, params.q);
+    let u = decompress_polyvec(
+        decode_to_polyvec::<256, 2>(c1, params.du),
+        params.du,
+        params.q,
+    );
     let v = decompress_poly(decode_to_poly(c2, params.dv), params.dv, params.q);
     let s = decode_to_polyvec(sk.clone(), 12);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,10 @@ pub type F3329 = PrimeField3329;
 pub type Poly3329<const N: usize> = Polynomial<F3329, N>;
 
 /// Polynomial vector R_q^k
-pub type PolyVec3329<const N: usize> = PolyVec<Poly3329<N>>;
+pub type PolyVec3329<const N: usize, const D: usize> = PolyVec<Poly3329<N>,D>;
 
 /// Polynomial matrix R_q^(k*k)
-pub type PolyMatrix3329<const N: usize> = Matrix<Poly3329<N>>;
+pub type PolyMatrix3329<const N: usize, const X: usize, const Y: usize> = Matrix<Poly3329<N>, X, Y>;
 
 /// Default length used for XOF
 const XOF_LEN: usize = 4000;
@@ -80,7 +80,7 @@ pub fn kyber_cpapke_key_gen(params: KyberParams) -> (ByteArray, ByteArray) {
         }
     }
 
-    let (mut s, mut e) = (PolyVec3329::init(k), PolyVec3329::init(k));
+    let (mut s, mut e) = (PolyVec3329::<256,2>::init(k), PolyVec3329::<256,2>::init(k));
     let prf_len = 64 * params.eta;
 
     for i in 0..k {
@@ -119,7 +119,7 @@ pub fn kyber_cpapke_enc(
         }
     }
 
-    let (mut r_bold, mut e1) = (PolyVec3329::init(params.k), PolyVec3329::init(params.k));
+    let (mut r_bold, mut e1) = (PolyVec3329::<256,2>::init(params.k), PolyVec3329::<256,2>::init(params.k));
     for i in 0..params.k {
         r_bold.set(i, cbd(prf(&r, i, prf_len), params.eta));
         e1.set(i, cbd(prf(&r, params.k + i, prf_len), params.eta));
@@ -145,7 +145,7 @@ pub fn kyber_cpapke_dec(params: KyberParams, sk: &ByteArray, c: &ByteArray) -> B
     let offset = params.du * params.k * params.n / 8;
     let (c1, c2) = c.split_at(offset);
 
-    let u = decompress_polyvec(decode_to_polyvec::<256>(c1, params.du), params.du, params.q);
+    let u = decompress_polyvec(decode_to_polyvec::<256,2>(c1, params.du), params.du, params.q);
     let v = decompress_poly(decode_to_poly(c2, params.dv), params.dv, params.q);
     let s = decode_to_polyvec(sk.clone(), 12);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub fn kyber_cpapke_key_gen(params: KyberParams) -> (ByteArray, ByteArray) {
     let d = ByteArray::random(32);
     let (rho, sigma) = g(&d);
 
-    let mut a = PolyMatrix3329::init_matrix(k, k);
+    let mut a = PolyMatrix3329::init();
 
     for i in 0..k {
         for j in 0..k {
@@ -111,7 +111,7 @@ pub fn kyber_cpapke_enc(
 
     let (t, rho) = pk.split_at(offset);
     let t_hat = decode_to_polyvec(t, 12);
-    let mut a_t = PolyMatrix3329::init_matrix(params.k, params.k);
+    let mut a_t = PolyMatrix3329::init();
 
     for i in 0..params.k {
         for j in 0..params.k {

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -58,7 +58,7 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
 }
 
 /// Base case multiplivation for vectors
-pub fn bcm_vec<const N: usize>(a: &PolyVec3329<N>, b: &PolyVec3329<N>) -> Poly3329<N> {
+pub fn bcm_vec<const N: usize, const D: usize>(a: &PolyVec3329<N,D>, b: &PolyVec3329<N,D>) -> Poly3329<N> {
     let l = a.dimension();
     assert_eq!(l, b.dimension());
 
@@ -70,7 +70,7 @@ pub fn bcm_vec<const N: usize>(a: &PolyVec3329<N>, b: &PolyVec3329<N>) -> Poly33
 }
 
 /// Matrix basecase multiplication, cf p. 7
-pub fn bcm_matrix_vec<const N: usize>(a: &PolyMatrix3329<N>, b: &PolyVec3329<N>) -> PolyVec3329<N> {
+pub fn bcm_matrix_vec<const N: usize, const X: usize, const Y: usize>(a: &PolyMatrix3329<N,X,Y>, b: &PolyVec3329<N,X>) -> PolyVec3329<N,Y> {
     let (x, y) = a.dimensions();
     assert_eq!(x, b.dimension());
 
@@ -89,17 +89,17 @@ pub fn ntt_product<const N: usize>(a_hat: &Poly3329<N>, b_hat: &Poly3329<N>) -> 
 }
 
 /// Computes a^T.b as NTT^-1(a_hat^T o b_hat)
-pub fn ntt_product_vec<const N: usize>(a_hat: &PolyVec3329<N>, b_hat: &PolyVec3329<N>) -> Poly3329<N> {
+pub fn ntt_product_vec<const N: usize, const D: usize>(a_hat: &PolyVec3329<N,D>, b_hat: &PolyVec3329<N,D>) -> Poly3329<N> {
     rev_ntt(&bcm_vec(a_hat, b_hat))
 }
 
 /// Computes a.b as NTT^-1(a_hat o b_hat)
-pub fn ntt_product_matvec<const N: usize>(a_hat: &PolyMatrix3329<N>, b_hat: &PolyVec3329<N>) -> PolyVec3329<N> {
+pub fn ntt_product_matvec<const N: usize, const X: usize, const Y: usize>(a_hat: &PolyMatrix3329<N,X,Y>, b_hat: &PolyVec3329<N,X>) -> PolyVec3329<N,Y> {
     rev_ntt_vec(&bcm_matrix_vec(a_hat, b_hat))
 }
 
 /// Number theoretic Transform on vectors
-pub fn ntt_vec<const N: usize>(p: &PolyVec3329<N>) -> PolyVec3329<N> {
+pub fn ntt_vec<const N: usize, const D: usize>(p: &PolyVec3329<N,D>) -> PolyVec3329<N,D> {
     let mut c = vec![];
     for p_i in p.coefficients.iter() {
         c.push(base_ntt(p_i));
@@ -108,7 +108,7 @@ pub fn ntt_vec<const N: usize>(p: &PolyVec3329<N>) -> PolyVec3329<N> {
 }
 
 /// Reverse NTT on vectors
-pub fn rev_ntt_vec<const N: usize>(p_hat: &PolyVec3329<N>) -> PolyVec3329<N> {
+pub fn rev_ntt_vec<const N: usize, const D: usize>(p_hat: &PolyVec3329<N,D>) -> PolyVec3329<N,D> {
     let mut c = vec![];
     for p_i in p_hat.coefficients.iter() {
         c.push(rev_ntt(p_i));

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -36,7 +36,7 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
 
     // BCM with the zero polynomial is the zero polynomial
     if a.is_zero() || b.is_zero() {
-        return a.zero();
+        return Poly3329::zero();
     }
     // Unwraps safely since the case None has been tested above
     let d = a.degree().unwrap();
@@ -74,7 +74,7 @@ pub fn bcm_matrix_vec<const N: usize, const X: usize, const Y: usize>(a: &PolyMa
     let (x, y) = a.dimensions();
     assert_eq!(x, b.dimension());
 
-    let mut v = PolyVec3329::init(y);
+    let mut v = PolyVec3329::init();
 
     for i in 0..y {
         v.set(i, bcm_vec(&a.row(i), &b))
@@ -122,7 +122,7 @@ pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
 
     // Zero polynomial's NTT is zero
     if p.is_zero() {
-        return p.zero();
+        return Poly3329::zero();
     }
 
     // Unwraps safely since the case None has been tested above
@@ -158,7 +158,7 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
 
     // Zero polynomial's NTT is zero
     if p_hat.is_zero() {
-        return p_hat.zero();
+        return Poly3329::zero();
     }
     // Unwraps safely since the case None has been tested above
     let d = p_hat.degree().unwrap();

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -32,18 +32,14 @@ pub fn byte_rev(i: usize) -> usize {
 
 /// Basecase multiplication between polynomials (p 7)
 pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
-    assert_eq!(a.degree(), b.degree());
-
     // BCM with the zero polynomial is the zero polynomial
     if a.is_zero() || b.is_zero() {
         return Poly3329::zero();
     }
-    // Unwraps safely since the case None has been tested above
-    let d = a.degree().unwrap();
-
+    
     let mut p = Poly3329::init();
 
-    for i in 0..=d / 2 {
+    for i in 0..=(N-1) / 2 {
         let zeta = F3329::from_int(ZETAS_256[2 * byte_rev(i) + 1]);
 
         let p01 = a[2 * i].mul(&b[2 * i]);
@@ -51,6 +47,7 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
 
         let p11 = a[2 * i].mul(&b[2 * i + 1]);
         let p12 = a[2 * i + 1].mul(&b[2 * i]);
+        
         p.set_coeff(2 * i, p01.add(&p02));
         p.set_coeff(2 * i + 1, p11.add(&p12));
     }
@@ -131,15 +128,12 @@ pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
         return Poly3329::zero();
     }
 
-    // Unwraps safely since the case None has been tested above
-    let d = p.degree().unwrap();
-
     // We assume d is even since spec requires operating mod X^2-zeta
-    for i in 0..=d / 2 {
+    for i in 0..=(N-1) / 2 {
         let mut p0 = p[0];
         let mut p1 = p[1];
 
-        for j in 1..=d / 2 {
+        for j in 1..=(N-1) / 2 {
             let index = (2 * byte_rev(i) * j + j) % 256;
             let zeta = F3329::from_int(ZETAS_256[index]);
             let mut c0 = p[2 * j];
@@ -171,12 +165,12 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
 
     let coeff = F3329::from_int((d / 2) + 1);
 
-    for i in 0..=d / 2 {
+    for i in 0..=(N-1) / 2 {
         let mut p0 = p_hat[0];
         let mut p1 = p_hat[1];
         let z = F3329::from_int(ZETAS_256[((256 - i) % 256)]);
 
-        for j in 1..=d / 2 {
+        for j in 1..=(N-1) / 2 {
             let index = (2 * byte_rev(i) * j) % 256;
             let zeta = F3329::from_int(ZETAS_256[(256 - index) % 256]);
             let mut c0 = p_hat[2 * j];
@@ -199,7 +193,7 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
 
 #[test]
 fn rev_then_ntt() {
-    let mut u_bold = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
+    let mut u_bold = Poly3329::from_vec([Default::default(); 256]);
     for i in 0..256 {
         u_bold.set_coeff(i, F3329::from_int(i));
     }
@@ -210,7 +204,7 @@ fn rev_then_ntt() {
 
 #[test]
 fn ntt_then_rev() {
-    let mut u = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
+    let mut u = Poly3329::from_vec([Default::default(); 256]);
     for i in 0..256 {
         u.set_coeff(i, F3329::from_int(i));
     }

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -41,7 +41,7 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
     // Unwraps safely since the case None has been tested above
     let d = a.degree().unwrap();
 
-    let mut p = Poly3329::init(a.dimension());
+    let mut p = Poly3329::init();
 
     for i in 0..=d / 2 {
         let zeta = F3329::from_int(ZETAS_256[2 * byte_rev(i) + 1]);
@@ -58,25 +58,25 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
 }
 
 /// Base case multiplivation for vectors
-pub fn bcm_vec<const N: usize, const D: usize>(a: &PolyVec3329<N,D>, b: &PolyVec3329<N,D>) -> Poly3329<N> {
-    let l = a.dimension();
-    assert_eq!(l, b.dimension());
-
+pub fn bcm_vec<const N: usize, const D: usize>(
+    a: &PolyVec3329<N, D>,
+    b: &PolyVec3329<N, D>,
+) -> Poly3329<N> {
     let mut p = bcm(&a.get(0), &b.get(0));
-    for i in 1..l {
+    for i in 1..D {
         p = p.add(&bcm(&a.get(i), &b.get(i)));
     }
     p
 }
 
 /// Matrix basecase multiplication, cf p. 7
-pub fn bcm_matrix_vec<const N: usize, const X: usize, const Y: usize>(a: &PolyMatrix3329<N,X,Y>, b: &PolyVec3329<N,X>) -> PolyVec3329<N,Y> {
-    let (x, y) = a.dimensions();
-    assert_eq!(x, b.dimension());
-
+pub fn bcm_matrix_vec<const N: usize, const X: usize, const Y: usize>(
+    a: &PolyMatrix3329<N, X, Y>,
+    b: &PolyVec3329<N, X>,
+) -> PolyVec3329<N, Y> {
     let mut v = PolyVec3329::init();
 
-    for i in 0..y {
+    for i in 0..Y {
         v.set(i, bcm_vec(&a.row(i), &b))
     }
 
@@ -89,17 +89,23 @@ pub fn ntt_product<const N: usize>(a_hat: &Poly3329<N>, b_hat: &Poly3329<N>) -> 
 }
 
 /// Computes a^T.b as NTT^-1(a_hat^T o b_hat)
-pub fn ntt_product_vec<const N: usize, const D: usize>(a_hat: &PolyVec3329<N,D>, b_hat: &PolyVec3329<N,D>) -> Poly3329<N> {
+pub fn ntt_product_vec<const N: usize, const D: usize>(
+    a_hat: &PolyVec3329<N, D>,
+    b_hat: &PolyVec3329<N, D>,
+) -> Poly3329<N> {
     rev_ntt(&bcm_vec(a_hat, b_hat))
 }
 
 /// Computes a.b as NTT^-1(a_hat o b_hat)
-pub fn ntt_product_matvec<const N: usize, const X: usize, const Y: usize>(a_hat: &PolyMatrix3329<N,X,Y>, b_hat: &PolyVec3329<N,X>) -> PolyVec3329<N,Y> {
+pub fn ntt_product_matvec<const N: usize, const X: usize, const Y: usize>(
+    a_hat: &PolyMatrix3329<N, X, Y>,
+    b_hat: &PolyVec3329<N, X>,
+) -> PolyVec3329<N, Y> {
     rev_ntt_vec(&bcm_matrix_vec(a_hat, b_hat))
 }
 
 /// Number theoretic Transform on vectors
-pub fn ntt_vec<const N: usize, const D: usize>(p: &PolyVec3329<N,D>) -> PolyVec3329<N,D> {
+pub fn ntt_vec<const N: usize, const D: usize>(p: &PolyVec3329<N, D>) -> PolyVec3329<N, D> {
     let mut c = vec![];
     for p_i in p.coefficients.iter() {
         c.push(base_ntt(p_i));
@@ -108,7 +114,7 @@ pub fn ntt_vec<const N: usize, const D: usize>(p: &PolyVec3329<N,D>) -> PolyVec3
 }
 
 /// Reverse NTT on vectors
-pub fn rev_ntt_vec<const N: usize, const D: usize>(p_hat: &PolyVec3329<N,D>) -> PolyVec3329<N,D> {
+pub fn rev_ntt_vec<const N: usize, const D: usize>(p_hat: &PolyVec3329<N, D>) -> PolyVec3329<N, D> {
     let mut c = vec![];
     for p_i in p_hat.coefficients.iter() {
         c.push(rev_ntt(p_i));
@@ -118,7 +124,7 @@ pub fn rev_ntt_vec<const N: usize, const D: usize>(p_hat: &PolyVec3329<N,D>) -> 
 
 /// Number theoretic Transform
 pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
-    let mut a = Poly3329::init(p.dimension());
+    let mut a = Poly3329::init();
 
     // Zero polynomial's NTT is zero
     if p.is_zero() {
@@ -154,7 +160,7 @@ pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
 
 /// Reverse NTT
 pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
-    let mut a = Poly3329::init(p_hat.dimension());
+    let mut a = Poly3329::init();
 
     // Zero polynomial's NTT is zero
     if p_hat.is_zero() {

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -151,8 +151,8 @@ pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
             p0 = p0.add(&c0);
             p1 = p1.add(&c1);
         }
-        a.set_coeff(2 * i,p0);
-        a.set_coeff(2 * i + 1,p1);
+        a.set_coeff(2 * i, p0);
+        a.set_coeff(2 * i + 1, p1);
     }
 
     a
@@ -190,8 +190,8 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
         }
 
         // Unwraps safely since coeff is d/2 + 1
-        a.set_coeff(2 * i,p0.mul(&z).div(&coeff).unwrap());
-        a.set_coeff(2 * i + 1,p1.mul(&z).div(&coeff).unwrap());
+        a.set_coeff(2 * i, p0.mul(&z).div(&coeff).unwrap());
+        a.set_coeff(2 * i + 1, p1.mul(&z).div(&coeff).unwrap());
     }
 
     a

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -4,7 +4,6 @@
 
 use crate::polyvec::structures::{FiniteField, FiniteRing, RingModule};
 use crate::{Poly3329, PolyMatrix3329, PolyVec3329, F3329};
-use std::convert::TryInto;
 
 /// 256-roots of unity
 const ZETAS_256: [usize; 256] = [
@@ -36,7 +35,12 @@ pub fn bcm(a: &Poly3329, b: &Poly3329) -> Poly3329 {
     assert_eq!(a.degree(), b.degree());
     assert_eq!(a.dimension(), b.dimension());
 
-    let d: usize = a.degree().try_into().unwrap();
+    // BCM with the zero polynomial is the zero polynomial
+    if a.is_zero() || b.is_zero() {
+        return a.zero();
+    }
+    // Unwraps safely since the case None has been tested above
+    let d = a.degree().unwrap();
 
     let mut p = Poly3329::init(a.dimension());
 
@@ -117,12 +121,13 @@ pub fn rev_ntt_vec(p_hat: &PolyVec3329) -> PolyVec3329 {
 pub fn base_ntt(p: &Poly3329) -> Poly3329 {
     let mut a = Poly3329::init(p.dimension());
 
-    if p.degree() < 0 {
-        // Zero polynomial's NTT is zero
-        return p.clone();
+    // Zero polynomial's NTT is zero
+    if p.is_zero() {
+        return p.zero();
     }
 
-    let d: usize = p.degree().try_into().unwrap();
+    // Unwraps safely since the case None has been tested above
+    let d = p.degree().unwrap();
 
     // We assume d is even since spec requires operating mod X^2-zeta
     for i in 0..=d / 2 {
@@ -152,12 +157,13 @@ pub fn base_ntt(p: &Poly3329) -> Poly3329 {
 pub fn rev_ntt(p_hat: &Poly3329) -> Poly3329 {
     let mut a = Poly3329::init(p_hat.dimension());
 
-    if p_hat.degree() < 0 {
-        // Zero polynomial's NTT is zero
-        return p_hat.clone();
+    // Zero polynomial's NTT is zero
+    if p_hat.is_zero() {
+        return p_hat.zero();
     }
+    // Unwraps safely since the case None has been tested above
+    let d = p_hat.degree().unwrap();
 
-    let d: usize = p_hat.degree().try_into().unwrap();
     let coeff = F3329::from_int((d / 2) + 1);
 
     for i in 0..=d / 2 {
@@ -177,6 +183,8 @@ pub fn rev_ntt(p_hat: &Poly3329) -> Poly3329 {
             p0 = p0.add(&c0);
             p1 = p1.add(&c1);
         }
+
+        // Unwraps safely since coeff is d/2 + 1
         a[2 * i] = p0.mul(&z).div(&coeff).unwrap();
         a[2 * i + 1] = p1.mul(&z).div(&coeff).unwrap();
     }

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -48,11 +48,11 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
 
         let p01 = a[2 * i].mul(&b[2 * i]);
         let p02 = a[2 * i + 1].mul(&b[2 * i + 1]).mul(&zeta);
-        p[2 * i] = p01.add(&p02);
 
         let p11 = a[2 * i].mul(&b[2 * i + 1]);
         let p12 = a[2 * i + 1].mul(&b[2 * i]);
-        p[2 * i + 1] = p11.add(&p12);
+        p.set_coeff(2 * i, p01.add(&p02));
+        p.set_coeff(2 * i + 1, p11.add(&p12));
     }
     p
 }
@@ -151,8 +151,8 @@ pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
             p0 = p0.add(&c0);
             p1 = p1.add(&c1);
         }
-        a[2 * i] = p0;
-        a[2 * i + 1] = p1;
+        a.set_coeff(2 * i,p0);
+        a.set_coeff(2 * i + 1,p1);
     }
 
     a
@@ -190,8 +190,8 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
         }
 
         // Unwraps safely since coeff is d/2 + 1
-        a[2 * i] = p0.mul(&z).div(&coeff).unwrap();
-        a[2 * i + 1] = p1.mul(&z).div(&coeff).unwrap();
+        a.set_coeff(2 * i,p0.mul(&z).div(&coeff).unwrap());
+        a.set_coeff(2 * i + 1,p1.mul(&z).div(&coeff).unwrap());
     }
 
     a
@@ -201,7 +201,7 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
 fn rev_then_ntt() {
     let mut u_bold = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
     for i in 0..256 {
-        u_bold[i] = F3329::from_int(i);
+        u_bold.set_coeff(i, F3329::from_int(i));
     }
     let u = rev_ntt(&u_bold);
 
@@ -212,7 +212,7 @@ fn rev_then_ntt() {
 fn ntt_then_rev() {
     let mut u = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
     for i in 0..256 {
-        u[i] = F3329::from_int(i);
+        u.set_coeff(i, F3329::from_int(i));
     }
     let u_bold = base_ntt(&u);
 

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -36,7 +36,7 @@ pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
     if a.is_zero() || b.is_zero() {
         return Poly3329::zero();
     }
-    
+
     let mut p = Poly3329::init();
 
     for i in 0..=(N-1) / 2 {
@@ -103,20 +103,20 @@ pub fn ntt_product_matvec<const N: usize, const X: usize, const Y: usize>(
 
 /// Number theoretic Transform on vectors
 pub fn ntt_vec<const N: usize, const D: usize>(p: &PolyVec3329<N, D>) -> PolyVec3329<N, D> {
-    let mut c = vec![];
-    for p_i in p.coefficients.iter() {
-        c.push(base_ntt(p_i));
+    let mut coeffs = [Default::default(); D];
+    for i in 0..D {
+        coeffs[i] = base_ntt(&p.coefficients[i]);
     }
-    PolyVec3329::from_vec(c)
+    PolyVec3329::from_vec(coeffs)
 }
 
 /// Reverse NTT on vectors
 pub fn rev_ntt_vec<const N: usize, const D: usize>(p_hat: &PolyVec3329<N, D>) -> PolyVec3329<N, D> {
-    let mut c = vec![];
-    for p_i in p_hat.coefficients.iter() {
-        c.push(rev_ntt(p_i));
+    let mut coeffs = [Default::default(); D];
+    for i in 0..D {
+        coeffs[i] = rev_ntt(&p_hat.coefficients[i]);
     }
-    PolyVec3329::from_vec(c)
+    PolyVec3329::from_vec(coeffs)
 }
 
 /// Number theoretic Transform

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -199,7 +199,7 @@ pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
 
 #[test]
 fn rev_then_ntt() {
-    let mut u_bold = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
+    let mut u_bold = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
     for i in 0..256 {
         u_bold[i] = F3329::from_int(i);
     }
@@ -210,7 +210,7 @@ fn rev_then_ntt() {
 
 #[test]
 fn ntt_then_rev() {
-    let mut u = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
+    let mut u = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
     for i in 0..256 {
         u[i] = F3329::from_int(i);
     }

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -31,9 +31,8 @@ pub fn byte_rev(i: usize) -> usize {
 }
 
 /// Basecase multiplication between polynomials (p 7)
-pub fn bcm(a: &Poly3329, b: &Poly3329) -> Poly3329 {
+pub fn bcm<const N: usize>(a: &Poly3329<N>, b: &Poly3329<N>) -> Poly3329<N> {
     assert_eq!(a.degree(), b.degree());
-    assert_eq!(a.dimension(), b.dimension());
 
     // BCM with the zero polynomial is the zero polynomial
     if a.is_zero() || b.is_zero() {
@@ -59,7 +58,7 @@ pub fn bcm(a: &Poly3329, b: &Poly3329) -> Poly3329 {
 }
 
 /// Base case multiplivation for vectors
-pub fn bcm_vec(a: &PolyVec3329, b: &PolyVec3329) -> Poly3329 {
+pub fn bcm_vec<const N: usize>(a: &PolyVec3329<N>, b: &PolyVec3329<N>) -> Poly3329<N> {
     let l = a.dimension();
     assert_eq!(l, b.dimension());
 
@@ -71,7 +70,7 @@ pub fn bcm_vec(a: &PolyVec3329, b: &PolyVec3329) -> Poly3329 {
 }
 
 /// Matrix basecase multiplication, cf p. 7
-pub fn bcm_matrix_vec(a: &PolyMatrix3329, b: &PolyVec3329) -> PolyVec3329 {
+pub fn bcm_matrix_vec<const N: usize>(a: &PolyMatrix3329<N>, b: &PolyVec3329<N>) -> PolyVec3329<N> {
     let (x, y) = a.dimensions();
     assert_eq!(x, b.dimension());
 
@@ -85,22 +84,22 @@ pub fn bcm_matrix_vec(a: &PolyMatrix3329, b: &PolyVec3329) -> PolyVec3329 {
 }
 
 /// Computes a.b as NTT^-1(a_hat o b_hat)
-pub fn ntt_product(a_hat: &Poly3329, b_hat: &Poly3329) -> Poly3329 {
+pub fn ntt_product<const N: usize>(a_hat: &Poly3329<N>, b_hat: &Poly3329<N>) -> Poly3329<N> {
     rev_ntt(&bcm(a_hat, b_hat))
 }
 
 /// Computes a^T.b as NTT^-1(a_hat^T o b_hat)
-pub fn ntt_product_vec(a_hat: &PolyVec3329, b_hat: &PolyVec3329) -> Poly3329 {
+pub fn ntt_product_vec<const N: usize>(a_hat: &PolyVec3329<N>, b_hat: &PolyVec3329<N>) -> Poly3329<N> {
     rev_ntt(&bcm_vec(a_hat, b_hat))
 }
 
 /// Computes a.b as NTT^-1(a_hat o b_hat)
-pub fn ntt_product_matvec(a_hat: &PolyMatrix3329, b_hat: &PolyVec3329) -> PolyVec3329 {
+pub fn ntt_product_matvec<const N: usize>(a_hat: &PolyMatrix3329<N>, b_hat: &PolyVec3329<N>) -> PolyVec3329<N> {
     rev_ntt_vec(&bcm_matrix_vec(a_hat, b_hat))
 }
 
 /// Number theoretic Transform on vectors
-pub fn ntt_vec(p: &PolyVec3329) -> PolyVec3329 {
+pub fn ntt_vec<const N: usize>(p: &PolyVec3329<N>) -> PolyVec3329<N> {
     let mut c = vec![];
     for p_i in p.coefficients.iter() {
         c.push(base_ntt(p_i));
@@ -109,7 +108,7 @@ pub fn ntt_vec(p: &PolyVec3329) -> PolyVec3329 {
 }
 
 /// Reverse NTT on vectors
-pub fn rev_ntt_vec(p_hat: &PolyVec3329) -> PolyVec3329 {
+pub fn rev_ntt_vec<const N: usize>(p_hat: &PolyVec3329<N>) -> PolyVec3329<N> {
     let mut c = vec![];
     for p_i in p_hat.coefficients.iter() {
         c.push(rev_ntt(p_i));
@@ -118,7 +117,7 @@ pub fn rev_ntt_vec(p_hat: &PolyVec3329) -> PolyVec3329 {
 }
 
 /// Number theoretic Transform
-pub fn base_ntt(p: &Poly3329) -> Poly3329 {
+pub fn base_ntt<const N: usize>(p: &Poly3329<N>) -> Poly3329<N> {
     let mut a = Poly3329::init(p.dimension());
 
     // Zero polynomial's NTT is zero
@@ -154,7 +153,7 @@ pub fn base_ntt(p: &Poly3329) -> Poly3329 {
 }
 
 /// Reverse NTT
-pub fn rev_ntt(p_hat: &Poly3329) -> Poly3329 {
+pub fn rev_ntt<const N: usize>(p_hat: &Poly3329<N>) -> Poly3329<N> {
     let mut a = Poly3329::init(p_hat.dimension());
 
     // Zero polynomial's NTT is zero
@@ -194,7 +193,7 @@ pub fn rev_ntt(p_hat: &Poly3329) -> Poly3329 {
 
 #[test]
 fn rev_then_ntt() {
-    let mut u_bold = Poly3329::from_vec(vec![Default::default(); 256], 256);
+    let mut u_bold = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
     for i in 0..256 {
         u_bold[i] = F3329::from_int(i);
     }
@@ -205,7 +204,7 @@ fn rev_then_ntt() {
 
 #[test]
 fn ntt_then_rev() {
-    let mut u = Poly3329::from_vec(vec![Default::default(); 256], 256);
+    let mut u = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
     for i in 0..256 {
         u[i] = F3329::from_int(i);
     }

--- a/src/polyvec/matrix.rs
+++ b/src/polyvec/matrix.rs
@@ -14,9 +14,6 @@ where
 {
     /// Internal representation as a list of elements of type `T`
     coefficients: Vec<K>,
-
-    /// Dimensions of the matrix
-    dimensions: (usize, usize),
 }
 
 impl<K, const X: usize, const Y: usize> Matrix<K, X, Y>
@@ -29,34 +26,31 @@ where
     pub fn init_matrix(col_num: usize, col_dim: usize) -> Self {
         Self {
             coefficients: vec![Default::default(); col_num * col_dim],
-            dimensions: (col_num, col_dim),
         }
     }
 
     /// Return the matrix dimensions
-    pub fn dimensions(&self) -> (usize, usize) {
-        self.dimensions
+    pub fn dimensions() -> (usize, usize) {
+        (X, Y)
     }
 
     /// Return a specific row
     pub fn row(&self, index: usize) -> PolyVec<K, X> {
-        let (cols, rows) = self.dimensions();
-        let mut t = PolyVec::<K,X>::init();
+        let mut t = PolyVec::<K, X>::init();
 
-        for i in 0..cols {
-            t.set(i, self.coefficients[index * rows + i].clone());
+        for i in 0..X {
+            t.set(i, self.coefficients[index * Y + i].clone());
         }
 
         t
     }
 
     /// Return a specific column
-    pub fn column(&self, index: usize) -> PolyVec<K,Y> {
-        let (cols, rows) = self.dimensions();
-        let mut t = PolyVec::<K,Y>::init();
+    pub fn column(&self, index: usize) -> PolyVec<K, Y> {
+        let mut t = PolyVec::<K, Y>::init();
 
-        for i in 0..rows {
-            t.set(i, self.coefficients[index * i + cols].clone());
+        for i in 0..Y {
+            t.set(i, self.coefficients[index * i + X].clone());
         }
 
         t
@@ -64,28 +58,22 @@ where
 
     /// Set a coefficient
     pub fn set(&mut self, row: usize, column: usize, value: K) {
-        let (cols, rows) = self.dimensions();
-        assert!((column < cols) && (row < rows));
-
-        self.coefficients[row * rows + column] = value;
+        assert!((column < X) && (row < Y));
+        self.coefficients[row * Y + column] = value;
     }
 
     /// Get a coefficient
     pub fn get(&self, row: usize, column: usize) -> K {
-        let (cols, rows) = self.dimensions();
-        assert!((column < cols) && (row < rows));
+        assert!((column < X) && (row < Y));
 
-        self.coefficients[row * rows + column].clone()
+        self.coefficients[row * Y + column].clone()
     }
 
     /// Perform a matrix vector multiplication
-    pub fn vec_mul(&self, v: &PolyVec<K,X>) -> PolyVec<K,Y> {
-        let (cols, rows) = self.dimensions();
-        assert!(v.dimension() == rows);
+    pub fn vec_mul(&self, v: &PolyVec<K, X>) -> PolyVec<K, Y> {
+        let mut t = PolyVec::<K, Y>::init();
 
-        let mut t = PolyVec::<K,Y>::init();
-
-        for j in 0..cols {
+        for j in 0..Y {
             t.set(j, v.dot(&self.row(j)));
         }
 
@@ -93,7 +81,7 @@ where
     }
 }
 
-impl<K, const X: usize, const Y: usize> fmt::Debug for Matrix<K,X,Y>
+impl<K, const X: usize, const Y: usize> fmt::Debug for Matrix<K, X, Y>
 where
     K: FiniteRing + Clone + Default + Debug,
 {

--- a/src/polyvec/matrix.rs
+++ b/src/polyvec/matrix.rs
@@ -8,12 +8,13 @@ use crate::polyvec::structures::{FiniteRing, RingModule};
 use std::fmt::{self, Debug};
 
 /// A `Matrix` is a collection of `Vector`s
+#[derive(Clone, Copy)]
 pub struct Matrix<K, const X: usize, const Y: usize>
 where
     K: FiniteRing + Clone + Default,
 {
     /// Internal representation as a list of elements of type `T`
-    coefficients: Vec<K>,
+    coefficients: [[K; X];Y],
 }
 
 impl<K, const X: usize, const Y: usize> Matrix<K, X, Y>
@@ -23,9 +24,9 @@ where
     /// Initialise an empty `Matrix`
     ///      - `col_num`: number of columns
     ///      - `col_dim`: number of rows
-    pub fn init_matrix(col_num: usize, col_dim: usize) -> Self {
+    pub fn init() -> Self {
         Self {
-            coefficients: vec![Default::default(); col_num * col_dim],
+            coefficients: [[Default::default(); X];Y],
         }
     }
 
@@ -36,13 +37,7 @@ where
 
     /// Return a specific row
     pub fn row(&self, index: usize) -> PolyVec<K, X> {
-        let mut t = PolyVec::<K, X>::init();
-
-        for i in 0..X {
-            t.set(i, self.coefficients[index * Y + i].clone());
-        }
-
-        t
+        PolyVec::<K, X>::from_vec(self.coefficients[index])
     }
 
     /// Return a specific column
@@ -50,7 +45,7 @@ where
         let mut t = PolyVec::<K, Y>::init();
 
         for i in 0..Y {
-            t.set(i, self.coefficients[index * i + X].clone());
+            t.set(i, self.coefficients[index * X][i].clone());
         }
 
         t
@@ -59,14 +54,13 @@ where
     /// Set a coefficient
     pub fn set(&mut self, row: usize, column: usize, value: K) {
         assert!((column < X) && (row < Y));
-        self.coefficients[row * X + column] = value;
+        self.coefficients[row][column] = value;
     }
 
     /// Get a coefficient
     pub fn get(&self, row: usize, column: usize) -> K {
         assert!((column < X) && (row < Y));
-
-        self.coefficients[row * X + column].clone()
+        self.coefficients[row][column]
     }
 
     /// Perform a matrix vector multiplication

--- a/src/polyvec/matrix.rs
+++ b/src/polyvec/matrix.rs
@@ -59,14 +59,14 @@ where
     /// Set a coefficient
     pub fn set(&mut self, row: usize, column: usize, value: K) {
         assert!((column < X) && (row < Y));
-        self.coefficients[row * Y + column] = value;
+        self.coefficients[row * X + column] = value;
     }
 
     /// Get a coefficient
     pub fn get(&self, row: usize, column: usize) -> K {
         assert!((column < X) && (row < Y));
 
-        self.coefficients[row * Y + column].clone()
+        self.coefficients[row * X + column].clone()
     }
 
     /// Perform a matrix vector multiplication

--- a/src/polyvec/matrix.rs
+++ b/src/polyvec/matrix.rs
@@ -8,7 +8,7 @@ use crate::polyvec::structures::{FiniteRing, RingModule};
 use std::fmt::{self, Debug};
 
 /// A `Matrix` is a collection of `Vector`s
-pub struct Matrix<K>
+pub struct Matrix<K, const X: usize, const Y: usize>
 where
     K: FiniteRing + Clone + Default,
 {
@@ -19,7 +19,7 @@ where
     dimensions: (usize, usize),
 }
 
-impl<K> Matrix<K>
+impl<K, const X: usize, const Y: usize> Matrix<K, X, Y>
 where
     K: FiniteRing + Clone + Default,
 {
@@ -39,9 +39,9 @@ where
     }
 
     /// Return a specific row
-    pub fn row(&self, index: usize) -> PolyVec<K> {
+    pub fn row(&self, index: usize) -> PolyVec<K, X> {
         let (cols, rows) = self.dimensions();
-        let mut t = PolyVec::<K>::init(cols);
+        let mut t = PolyVec::<K,X>::init(cols);
 
         for i in 0..cols {
             t.set(i, self.coefficients[index * rows + i].clone());
@@ -51,9 +51,9 @@ where
     }
 
     /// Return a specific column
-    pub fn column(&self, index: usize) -> PolyVec<K> {
+    pub fn column(&self, index: usize) -> PolyVec<K,Y> {
         let (cols, rows) = self.dimensions();
-        let mut t = PolyVec::<K>::init(rows);
+        let mut t = PolyVec::<K,Y>::init(rows);
 
         for i in 0..rows {
             t.set(i, self.coefficients[index * i + cols].clone());
@@ -79,11 +79,11 @@ where
     }
 
     /// Perform a matrix vector multiplication
-    pub fn vec_mul(&self, v: &PolyVec<K>) -> PolyVec<K> {
+    pub fn vec_mul(&self, v: &PolyVec<K,X>) -> PolyVec<K,Y> {
         let (cols, rows) = self.dimensions();
         assert!(v.dimension() == rows);
 
-        let mut t = PolyVec::<K>::init(cols);
+        let mut t = PolyVec::<K,Y>::init(cols);
 
         for j in 0..cols {
             t.set(j, v.dot(&self.row(j)));
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl<K> fmt::Debug for Matrix<K>
+impl<K, const X: usize, const Y: usize> fmt::Debug for Matrix<K,X,Y>
 where
     K: FiniteRing + Clone + Default + Debug,
 {

--- a/src/polyvec/matrix.rs
+++ b/src/polyvec/matrix.rs
@@ -18,7 +18,7 @@ where
 
 impl<K, const X: usize, const Y: usize> Matrix<K, X, Y>
 where
-    K: FiniteRing + Clone + Default,
+    K: FiniteRing + Clone + Default + Copy,
 {
     /// Initialise an empty `Matrix`
     ///      - `col_num`: number of columns

--- a/src/polyvec/matrix.rs
+++ b/src/polyvec/matrix.rs
@@ -41,7 +41,7 @@ where
     /// Return a specific row
     pub fn row(&self, index: usize) -> PolyVec<K, X> {
         let (cols, rows) = self.dimensions();
-        let mut t = PolyVec::<K,X>::init(cols);
+        let mut t = PolyVec::<K,X>::init();
 
         for i in 0..cols {
             t.set(i, self.coefficients[index * rows + i].clone());
@@ -53,7 +53,7 @@ where
     /// Return a specific column
     pub fn column(&self, index: usize) -> PolyVec<K,Y> {
         let (cols, rows) = self.dimensions();
-        let mut t = PolyVec::<K,Y>::init(rows);
+        let mut t = PolyVec::<K,Y>::init();
 
         for i in 0..rows {
             t.set(i, self.coefficients[index * i + cols].clone());
@@ -83,7 +83,7 @@ where
         let (cols, rows) = self.dimensions();
         assert!(v.dimension() == rows);
 
-        let mut t = PolyVec::<K,Y>::init(cols);
+        let mut t = PolyVec::<K,Y>::init();
 
         for j in 0..cols {
             t.set(j, v.dot(&self.row(j)));

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -162,7 +162,7 @@ where
 {
     /// Init polynomial with a default value
     pub fn init() -> Self {
-        Self::from_vec(vec![Default::default(); N], N)
+        Self::from_vec(vec![Default::default(); N])
     }
 
     /// Return dimension of the Rq module
@@ -171,12 +171,13 @@ where
     }
 
     /// Init polynomial with specified coefficients
-    pub fn from_vec(coefficients: Vec<T>, n: usize) -> Self {
+    pub fn from_vec(mut coefficients: Vec<T>) -> Self {
         // For now we make it an error to input more coefficients than we can handle
         // In the future maybe we want to handle this more gracefully
-        assert!(coefficients.len() <= n);
+        assert!(coefficients.len() <= N);
+        coefficients.truncate(N);
 
-        let degree = (n.min(coefficients.len()) - 1).try_into().unwrap();
+        let degree = (N.min(coefficients.len()) - 1).try_into().unwrap();
 
         // Check for zero polynomial
         if degree == 0 && coefficients[0].eq(&T::zero()) {
@@ -208,7 +209,7 @@ where
         for i in 0..degree {
             v[i] = self.coefficients[i].mul(other)
         }
-        Self::from_vec(v, N)
+        Self::from_vec(v)
     }
 }
 

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -30,14 +30,14 @@ where
     }
 
     fn zero() -> Self {
-        Polynomial {
+        Self {
             coefficients: vec![T::zero()],
             degree: None,
         }
     }
 
     fn one() -> Self {
-        Polynomial {
+        Self {
             coefficients: vec![T::one()],
             degree: Some(0),
         }
@@ -55,7 +55,7 @@ where
         for (i, c) in self.coefficients.iter().enumerate() {
             coefficients[i] = c.neg();
         }
-        Polynomial {
+        Self {
             coefficients,
             degree: Some(degree),
         }
@@ -86,7 +86,7 @@ where
             return Self::zero();
         }
 
-        Polynomial {
+        Self {
             coefficients,
             degree: Some(degree),
         }
@@ -180,13 +180,10 @@ where
 
         // Check for zero polynomial
         if degree == 0 && coefficients[0].eq(&T::zero()) {
-            return Polynomial {
-                coefficients: vec![T::zero()],
-                degree: None,
-            };
+            return Self::zero()
         }
 
-        Polynomial {
+        Self {
             coefficients,
             degree: Some(degree),
         }

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -6,13 +6,13 @@ use crate::polyvec::structures::{FiniteField, FiniteRing};
 use std::ops::Index;
 
 /// Represents a polynomial in the ring T[X]/(X^n + 1)
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Polynomial<T, const N: usize>
 where
     T: FiniteField + Default,
 {
     /// Coefficients of the polynomial
-    pub coefficients: Vec<T>,
+    pub coefficients: [T; N],
 
     /// Degree of the polynomial (the zero polynomial has degree < 0)
     pub degree: Option<usize>,
@@ -20,7 +20,7 @@ where
 
 impl<T, const N: usize> FiniteRing for Polynomial<T, N>
 where
-    T: FiniteField + Clone + Default,
+    T: FiniteField + Clone + Default + Copy,
 {
     fn is_zero(&self) -> bool {
         self.degree().is_none()
@@ -28,16 +28,15 @@ where
 
     fn zero() -> Self {
         Self {
-            coefficients: vec![T::zero()],
+            coefficients: [T::zero(); N],
             degree: None,
         }
     }
 
     fn one() -> Self {
-        Self {
-            coefficients: vec![T::one()],
-            degree: Some(0),
-        }
+        let mut p = Self::zero();
+        p.set_coeff(0, T::one());
+        p
     }
 
     fn neg(&self) -> Self {
@@ -45,16 +44,14 @@ where
         if self.is_zero() {
             return Self::zero();
         }
-        // Unwraps safely since the case None has been tested above
-        let degree = self.degree().unwrap();
 
-        let mut coefficients = vec![T::zero(); degree + 1];
+        let mut coefficients = [T::zero(); N];
         for (i, c) in self.coefficients.iter().enumerate() {
             coefficients[i] = c.neg();
         }
         Self {
             coefficients,
-            degree: Some(degree),
+            degree: self.degree,
         }
     }
 
@@ -66,9 +63,9 @@ where
         // Unwraps safely since the case None has been tested above
         let mut degree: usize = self.degree().unwrap().max(other.degree().unwrap());
 
-        let mut coefficients = vec![T::zero(); degree + 1];
-        for (i, c) in self.coefficients.iter().enumerate() {
-            coefficients[i] = other.coefficients[i].add(c);
+        let mut coefficients = [T::zero(); N];
+        for i in 0..N {
+            coefficients[i] = self[i].add(&other[i]);
         }
 
         // Diminish degree if leading coefficient is zero
@@ -94,17 +91,15 @@ where
     }
 
     fn mul(&self, other: &Self) -> Self {
-        if self.is_zero() {
-            return self.clone();
+        if self.is_zero() || other.is_zero() {
+            return Self::zero();
         }
-        if other.is_zero() {
-            return other.clone();
-        }
-        let coeffs = vec![T::zero(); N];
 
-        for (i, a) in self.coefficients.iter().enumerate() {
-            for (j, b) in other.coefficients.iter().enumerate() {
-                let c = a.mul(&b);
+        let coeffs = [T::zero(); N];
+
+        for i in 0..N {
+            for j in 0..N {
+                let c = self[i].mul(&other[j]);
                 let k = i + j;
                 if k < N {
                     coeffs[k].add(&c);
@@ -142,8 +137,8 @@ where
             return false;
         }
 
-        for (i, c) in self.coefficients.iter().enumerate() {
-            if !c.eq(&other.coefficients[i]) {
+        for i in 0..N {
+            if !self[i].eq(&other[i]) {
                 return false;
             }
         }
@@ -155,11 +150,11 @@ impl<T, const N: usize> Eq for Polynomial<T, N> where T: FiniteField + Default {
 
 impl<T, const N: usize> Polynomial<T, N>
 where
-    T: FiniteField + Clone + Default,
+    T: FiniteField + Clone + Default + Copy,
 {
     /// Init polynomial with a default value
     pub fn init() -> Self {
-        Self::from_vec(vec![Default::default(); N])
+        Self::from_vec([Default::default(); N])
     }
 
     /// Return dimension of the Rq module
@@ -169,12 +164,14 @@ where
 
     /// Init polynomial with specified coefficients
     /// If the array is bigger than N, only the first N values are taken
-    pub fn from_vec(mut coefficients: Vec<T>) -> Self {
-        coefficients.truncate(N);
+    pub fn from_vec(coefficients: [T; N]) -> Self {
+        // Reduce degree if appropriate
+        let mut degree = N - 1;
+        while degree > 0 && coefficients[degree].eq(&T::zero()) {
+            degree -= 1;
+        }
 
-        let degree = N.min(coefficients.len()) - 1;
-
-        // Check for zero polynomial
+        // Check for null polynomial (shouldn't happen but still)
         if degree == 0 && coefficients[0].eq(&T::zero()) {
             return Self::zero();
         }
@@ -199,7 +196,7 @@ where
         // Unwraps safely since the case None has been tested above
         let degree = self.degree().unwrap();
 
-        let mut v = vec![];
+        let mut v = [Default::default(); N];
 
         for i in 0..degree {
             v[i] = self.coefficients[i].mul(other)
@@ -211,20 +208,13 @@ where
     /// Ignores values beyond the dimension of the polynomial
     pub fn set_coeff(&mut self, index: usize, val: T) {
         if index < N && !val.is_zero() {
-            let degree = match self.degree() {
-                Some(d) if d < index => index,
-                None => index,
-                Some(d) => d,
+            self.degree = match self.degree() {
+                Some(d) if d < index => Some(index),
+                None => Some(index),
+                Some(d) => Some(d),
             };
 
-            let mut coefficients = self.coefficients.clone();
-
-            // Safe unwrap since degree becomes index if it was None
-            coefficients.resize(degree + 1, T::zero());
-            coefficients[index] = val;
-
-            self.degree = Some(degree);
-            self.coefficients = coefficients;
+            self.coefficients[index] = val;
         }
     }
 }
@@ -242,7 +232,7 @@ where
 
 impl<T, const N: usize> Default for Polynomial<T, N>
 where
-    T: FiniteField + Clone + Default,
+    T: FiniteField + Clone + Default + Copy,
 {
     fn default() -> Self {
         Self::init()

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -32,74 +32,70 @@ where
         self.degree().is_none()
     }
 
-    fn zero(&self) -> Self {
-        let t: T = Default::default();
+    fn zero() -> Self {
         Polynomial {
-            coefficients: vec![t.zero()],
+            coefficients: vec![T::zero()],
             degree: None,
-            n: self.n,
+            n: N,
         }
     }
 
-    fn one(&self) -> Self {
-        let t: T = Default::default();
+    fn one() -> Self {
         Polynomial {
-            coefficients: vec![t.one()],
+            coefficients: vec![T::one()],
             degree: Some(0),
-            n: self.n,
+            n: N,
         }
     }
 
     fn neg(&self) -> Self {
         // If the polynomial is already zero, do nothing
         if self.is_zero() {
-            return self.zero();
+            return Self::zero();
         }
         // Unwraps safely since the case None has been tested above
         let degree = self.degree().unwrap();
 
-        let t: T = Default::default();
-        let mut coefficients = vec![t.zero(); degree + 1];
+        let mut coefficients = vec![T::zero(); degree + 1];
         for (i, c) in self.coefficients.iter().enumerate() {
             coefficients[i] = c.neg();
         }
         Polynomial {
             coefficients,
             degree: Some(degree),
-            n: self.n,
+            n: N,
         }
     }
 
     fn add(&self, other: &Self) -> Self {
         // If one of the polynomial is already zero, do nothing
         if self.is_zero() || other.is_zero() {
-            return other.zero();
+            return Self::zero();
         }
         // Unwraps safely since the case None has been tested above
         let mut degree: usize = self.degree().unwrap().max(other.degree().unwrap());
 
-        let t: T = Default::default();
-        let mut coefficients = vec![t.zero(); degree + 1];
+        let mut coefficients = vec![T::zero(); degree + 1];
         for (i, c) in self.coefficients.iter().enumerate() {
             coefficients[i] = other.coefficients[i].add(c);
         }
 
         // Diminish degree if leading coefficient is zero
         let mut leading = &coefficients[degree];
-        while degree > 0 && leading.eq(&t.zero()) {
+        while degree > 0 && leading.eq(&T::zero()) {
             degree -= 1;
             leading = &coefficients[degree];
         }
 
         // Check whether the result is zero
-        if degree == 0 && leading.eq(&t.zero()) {
-            return self.zero();
+        if degree == 0 && leading.eq(&T::zero()) {
+            return Self::zero();
         }
 
         Polynomial {
             coefficients,
             degree: Some(degree),
-            n: self.n,
+            n: N,
         }
     }
 
@@ -114,9 +110,7 @@ where
         if other.is_zero() {
             return other.clone();
         }
-
-        let t: T = Default::default();
-        let coeffs = vec![t.zero(); self.n];
+        let coeffs = vec![T::zero(); self.n];
 
         for (i, a) in self.coefficients.iter().enumerate() {
             for (j, b) in other.coefficients.iter().enumerate() {
@@ -133,13 +127,13 @@ where
 
         // Reduce degree if appropriate
         let mut degree = self.n - 1;
-        while degree > 0 && coeffs[degree].eq(&t.zero()) {
+        while degree > 0 && coeffs[degree].eq(&T::zero()) {
             degree -= 1;
         }
 
         // Check for null polynomial (shouldn't happen but still)
-        if degree == 0 && coeffs[0].eq(&t.zero()) {
-            return self.zero();
+        if degree == 0 && coeffs[0].eq(&T::zero()) {
+            return Self::zero();
         }
 
         Self {
@@ -191,12 +185,11 @@ where
         assert!(coefficients.len() <= n);
 
         let degree = (n.min(coefficients.len()) - 1).try_into().unwrap();
-            
-        let t: T = Default::default();
+
         // Check for zero polynomial
-        if degree == 0 && coefficients[0].eq(&t.zero()) {
+        if degree == 0 && coefficients[0].eq(&T::zero()) {
             return Polynomial {
-                coefficients: vec![t.zero()],
+                coefficients: vec![T::zero()],
                 degree: None,
                 n,
             };
@@ -218,7 +211,7 @@ where
     pub fn mulf(&self, other: &T) -> Self {
         // If the polynomial or the scalar is already zero, do nothing
         if self.is_zero() || other.is_zero() {
-            return self.zero();
+            return Self::zero();
         }
         // Unwraps safely since the case None has been tested above
         let degree = self.degree().unwrap();

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -10,7 +10,7 @@ use std::{
 
 /// Represents a polynomial in the ring T[X]/(X^n + 1)
 #[derive(Clone)]
-pub struct Polynomial<T>
+pub struct Polynomial<T, const N: usize>
 where
     T: FiniteField + Default,
 {
@@ -24,7 +24,7 @@ where
     pub n: usize,
 }
 
-impl<T> FiniteRing for Polynomial<T>
+impl<T, const N: usize> FiniteRing for Polynomial<T, N>
 where
     T: FiniteField + Clone + Default,
 {
@@ -150,7 +150,7 @@ where
     }
 }
 
-impl<T> PartialEq for Polynomial<T>
+impl<T, const N: usize> PartialEq for Polynomial<T, N>
 where
     T: FiniteField + Default,
 {
@@ -168,9 +168,9 @@ where
     }
 }
 
-impl<T> Eq for Polynomial<T> where T: FiniteField + Default {}
+impl<T, const N: usize> Eq for Polynomial<T, N> where T: FiniteField + Default {}
 
-impl<T> Polynomial<T>
+impl<T, const N: usize> Polynomial<T, N>
 where
     T: FiniteField + Clone + Default,
 {
@@ -232,7 +232,7 @@ where
     }
 }
 
-impl<T> Index<usize> for Polynomial<T>
+impl<T, const N: usize> Index<usize> for Polynomial<T, N>
 where
     T: FiniteField + Default,
 {
@@ -243,7 +243,7 @@ where
     }
 }
 
-impl<T> IndexMut<usize> for Polynomial<T>
+impl<T,const N: usize> IndexMut<usize> for Polynomial<T, N>
 where
     T: FiniteField + Default,
 {
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<T> Default for Polynomial<T>
+impl<T, const N: usize> Default for Polynomial<T, N>
 where
     T: FiniteField + Clone + Default,
 {

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -19,9 +19,6 @@ where
 
     /// Degree of the polynomial (the zero polynomial has degree < 0)
     pub degree: Option<usize>,
-
-    /// Dimension of the ring as as a vector space over T
-    pub n: usize,
 }
 
 impl<T, const N: usize> FiniteRing for Polynomial<T, N>
@@ -36,7 +33,6 @@ where
         Polynomial {
             coefficients: vec![T::zero()],
             degree: None,
-            n: N,
         }
     }
 
@@ -44,7 +40,6 @@ where
         Polynomial {
             coefficients: vec![T::one()],
             degree: Some(0),
-            n: N,
         }
     }
 
@@ -63,7 +58,6 @@ where
         Polynomial {
             coefficients,
             degree: Some(degree),
-            n: N,
         }
     }
 
@@ -95,7 +89,6 @@ where
         Polynomial {
             coefficients,
             degree: Some(degree),
-            n: N,
         }
     }
 
@@ -110,23 +103,23 @@ where
         if other.is_zero() {
             return other.clone();
         }
-        let coeffs = vec![T::zero(); self.n];
+        let coeffs = vec![T::zero(); N];
 
         for (i, a) in self.coefficients.iter().enumerate() {
             for (j, b) in other.coefficients.iter().enumerate() {
                 let c = a.mul(&b);
                 let k = i + j;
-                if k < self.n {
+                if k < N {
                     coeffs[k].add(&c);
                 } else {
                     // X^n = -1
-                    coeffs[k % self.n].sub(&c);
+                    coeffs[k % N].sub(&c);
                 }
             }
         }
 
         // Reduce degree if appropriate
-        let mut degree = self.n - 1;
+        let mut degree = N - 1;
         while degree > 0 && coeffs[degree].eq(&T::zero()) {
             degree -= 1;
         }
@@ -139,7 +132,6 @@ where
         Self {
             coefficients: coeffs,
             degree: Some(degree),
-            n: self.n,
         }
     }
 }
@@ -169,13 +161,13 @@ where
     T: FiniteField + Clone + Default,
 {
     /// Init polynomial with a default value
-    pub fn init(n: usize) -> Self {
-        Self::from_vec(vec![Default::default(); n], n)
+    pub fn init() -> Self {
+        Self::from_vec(vec![Default::default(); N], N)
     }
 
     /// Return dimension of the Rq module
-    pub fn dimension(&self) -> usize {
-        self.n
+    pub fn dimension() -> usize {
+        N
     }
 
     /// Init polynomial with specified coefficients
@@ -191,14 +183,12 @@ where
             return Polynomial {
                 coefficients: vec![T::zero()],
                 degree: None,
-                n,
             };
         }
 
         Polynomial {
             coefficients,
             degree: Some(degree),
-            n,
         }
     }
 
@@ -221,7 +211,7 @@ where
         for i in 0..degree {
             v[i] = self.coefficients[i].mul(other)
         }
-        Self::from_vec(v, self.n)
+        Self::from_vec(v, N)
     }
 }
 
@@ -236,7 +226,7 @@ where
     }
 }
 
-impl<T,const N: usize> IndexMut<usize> for Polynomial<T, N>
+impl<T, const N: usize> IndexMut<usize> for Polynomial<T, N>
 where
     T: FiniteField + Default,
 {
@@ -250,6 +240,6 @@ where
     T: FiniteField + Clone + Default,
 {
     fn default() -> Self {
-        Self::init(1)
+        Self::init()
     }
 }

--- a/src/polyvec/polynomial.rs
+++ b/src/polyvec/polynomial.rs
@@ -3,9 +3,7 @@
 //! Polynomial structure
 
 use crate::polyvec::structures::{FiniteField, FiniteRing};
-use std::{
-    ops::Index
-};
+use std::ops::Index;
 
 /// Represents a polynomial in the ring T[X]/(X^n + 1)
 #[derive(Clone)]
@@ -170,17 +168,15 @@ where
     }
 
     /// Init polynomial with specified coefficients
+    /// If the array is bigger than N, only the first N values are taken
     pub fn from_vec(mut coefficients: Vec<T>) -> Self {
-        // For now we make it an error to input more coefficients than we can handle
-        // In the future maybe we want to handle this more gracefully
-        assert!(coefficients.len() <= N);
         coefficients.truncate(N);
 
         let degree = N.min(coefficients.len()) - 1;
 
         // Check for zero polynomial
         if degree == 0 && coefficients[0].eq(&T::zero()) {
-            return Self::zero()
+            return Self::zero();
         }
 
         Self {
@@ -215,7 +211,6 @@ where
     /// Ignores values beyond the dimension of the polynomial
     pub fn set_coeff(&mut self, index: usize, val: T) {
         if index < N && !val.is_zero() {
-
             let degree = match self.degree() {
                 Some(d) if d < index => index,
                 None => index,
@@ -223,7 +218,6 @@ where
             };
 
             let mut coefficients = self.coefficients.clone();
-
 
             // Safe unwrap since degree becomes index if it was None
             coefficients.resize(degree + 1, T::zero());
@@ -233,7 +227,6 @@ where
             self.coefficients = coefficients;
         }
     }
-
 }
 
 impl<T, const N: usize> Index<usize> for Polynomial<T, N>

--- a/src/polyvec/polyvec.rs
+++ b/src/polyvec/polyvec.rs
@@ -26,28 +26,24 @@ where
         self.coefficients[position] = value;
     }
 
-    fn zero(&self) -> Self {
-        Self::init(self.dimension())
+    fn zero() -> Self {
+        Self::init()
     }
 
-    fn basis_vector(&self, position: usize) -> Self {
-        assert!(position < self.dimension());
-
-        let t: T = Default::default();
-        let mut coefficients = vec![t.zero(); self.dimension()];
-        coefficients[position] = t.one();
+    fn basis_vector(position: usize) -> Self {
+        let mut coefficients = vec![T::zero(); D];
+        coefficients[position] = T::one();
 
         Self {
             coefficients,
-            dimension: self.dimension(),
+            dimension: D,
         }
     }
 
-    fn init(dimension: usize) -> Self {
-        let t: T = Default::default();
+    fn init() -> Self {
         Self {
-            coefficients: vec![t.zero(); dimension],
-            dimension,
+            coefficients: vec![T::zero(); D],
+            dimension: D,
         }
     }
 
@@ -60,8 +56,7 @@ where
     }
 
     fn neg(&self) -> Self {
-        let t = Self::init(self.dimension());
-        t.sub(self)
+        Self::init().sub(self)
     }
 
     fn dimension(&self) -> usize {
@@ -90,8 +85,7 @@ where
 
     fn dot(&self, other: &Self) -> T {
         assert_eq!(self.dimension(), other.dimension());
-        let t: T = Default::default();
-        let mut v = t.zero();
+        let mut v = T::zero();
 
         for i in 0..self.dimension() {
             v = v.add(&self.coefficients[i].mul(&other.coefficients[i]))

--- a/src/polyvec/polyvec.rs
+++ b/src/polyvec/polyvec.rs
@@ -9,12 +9,9 @@ use crate::polyvec::structures::{FiniteRing, RingModule};
 pub struct PolyVec<T: FiniteRing, const D: usize> {
     /// Vector coefficients
     pub coefficients: Vec<T>,
-
-    /// Size of vector
-    pub dimension: usize,
 }
 
-impl<T, const D: usize> RingModule<T> for PolyVec<T,D>
+impl<T, const D: usize> RingModule<T> for PolyVec<T, D>
 where
     T: FiniteRing + Clone + Default,
 {
@@ -34,60 +31,49 @@ where
         let mut coefficients = vec![T::zero(); D];
         coefficients[position] = T::one();
 
-        Self {
-            coefficients,
-            dimension: D,
-        }
+        Self { coefficients }
     }
 
     fn init() -> Self {
         Self {
             coefficients: vec![T::zero(); D],
-            dimension: D,
         }
     }
 
     fn is_zero(&self) -> bool {
-        if self.dimension == 0 {
-            true
-        } else {
-            self.coefficients.iter().all(|c| c.is_zero())
-        }
+        D == 0 || self.coefficients.iter().all(|c| c.is_zero())
     }
 
     fn neg(&self) -> Self {
         Self::init().sub(self)
     }
 
-    fn dimension(&self) -> usize {
-        self.dimension
+    fn dimension() -> usize {
+        D
     }
 
     fn add(&self, other: &Self) -> Self {
-        assert_eq!(self.dimension(), other.dimension());
-        let mut v = vec![Default::default(); self.dimension()];
+        let mut v = vec![Default::default(); D];
 
-        for i in 0..self.dimension() {
+        for i in 0..D {
             v[i] = self.coefficients[i].add(&other.coefficients[i]);
         }
         Self::from_vec(v)
     }
 
     fn sub(&self, other: &Self) -> Self {
-        assert_eq!(self.dimension(), other.dimension());
         let mut v = vec![];
 
-        for i in 0..self.dimension() {
+        for i in 0..D {
             v[i] = self.coefficients[i].sub(&other.coefficients[i])
         }
         Self::from_vec(v)
     }
 
     fn dot(&self, other: &Self) -> T {
-        assert_eq!(self.dimension(), other.dimension());
         let mut v = T::zero();
 
-        for i in 0..self.dimension() {
+        for i in 0..D {
             v = v.add(&self.coefficients[i].mul(&other.coefficients[i]))
         }
         v
@@ -96,7 +82,7 @@ where
     fn mulf(&self, other: &T) -> Self {
         let mut v = vec![];
 
-        for i in 0..self.dimension() {
+        for i in 0..D {
             v[i] = self.coefficients[i].mul(other)
         }
         Self::from_vec(v)
@@ -110,7 +96,6 @@ where
     fn default() -> Self {
         Self {
             coefficients: vec![],
-            dimension: 0,
         }
     }
 }
@@ -120,10 +105,6 @@ where
     T: FiniteRing + Clone + Default,
 {
     pub fn from_vec(coefficients: Vec<T>) -> Self {
-        let dimension = coefficients.len();
-        Self {
-            coefficients,
-            dimension,
-        }
+        Self { coefficients }
     }
 }

--- a/src/polyvec/polyvec.rs
+++ b/src/polyvec/polyvec.rs
@@ -6,7 +6,7 @@ use crate::polyvec::structures::{FiniteRing, RingModule};
 
 /// Polyvec
 #[derive(Clone)]
-pub struct PolyVec<T: FiniteRing> {
+pub struct PolyVec<T: FiniteRing, const D: usize> {
     /// Vector coefficients
     pub coefficients: Vec<T>,
 
@@ -14,7 +14,7 @@ pub struct PolyVec<T: FiniteRing> {
     pub dimension: usize,
 }
 
-impl<T> RingModule<T> for PolyVec<T>
+impl<T, const D: usize> RingModule<T> for PolyVec<T,D>
 where
     T: FiniteRing + Clone + Default,
 {
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl<T> Default for PolyVec<T>
+impl<T, const D: usize> Default for PolyVec<T, D>
 where
     T: FiniteRing,
 {
@@ -121,7 +121,7 @@ where
     }
 }
 
-impl<T> PolyVec<T>
+impl<T, const D: usize> PolyVec<T, D>
 where
     T: FiniteRing + Clone + Default,
 {

--- a/src/polyvec/polyvec.rs
+++ b/src/polyvec/polyvec.rs
@@ -5,15 +5,15 @@
 use crate::polyvec::structures::{FiniteRing, RingModule};
 
 /// Polyvec
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct PolyVec<T: FiniteRing, const D: usize> {
     /// Vector coefficients
-    pub coefficients: Vec<T>,
+    pub coefficients: [T; D],
 }
 
 impl<T, const D: usize> RingModule<T> for PolyVec<T, D>
 where
-    T: FiniteRing + Clone + Default,
+    T: FiniteRing + Clone + Default + Copy,
 {
     fn get(&self, position: usize) -> T {
         self.coefficients[position].clone()
@@ -28,15 +28,15 @@ where
     }
 
     fn basis_vector(position: usize) -> Self {
-        let mut coefficients = vec![T::zero(); D];
-        coefficients[position] = T::one();
+        let mut v = Self::zero();
+        v.coefficients[position] = T::one();
 
-        Self { coefficients }
+        v
     }
 
     fn init() -> Self {
         Self {
-            coefficients: vec![T::zero(); D],
+            coefficients: [T::zero(); D],
         }
     }
 
@@ -53,7 +53,7 @@ where
     }
 
     fn add(&self, other: &Self) -> Self {
-        let mut v = vec![Default::default(); D];
+        let mut v = [Default::default(); D];
 
         for i in 0..D {
             v[i] = self.coefficients[i].add(&other.coefficients[i]);
@@ -62,7 +62,7 @@ where
     }
 
     fn sub(&self, other: &Self) -> Self {
-        let mut v = vec![];
+        let mut v = [Default::default(); D];
 
         for i in 0..D {
             v[i] = self.coefficients[i].sub(&other.coefficients[i])
@@ -80,7 +80,7 @@ where
     }
 
     fn mulf(&self, other: &T) -> Self {
-        let mut v = vec![];
+        let mut v = [Default::default(); D];
 
         for i in 0..D {
             v[i] = self.coefficients[i].mul(other)
@@ -91,11 +91,11 @@ where
 
 impl<T, const D: usize> Default for PolyVec<T, D>
 where
-    T: FiniteRing,
+    T: FiniteRing + Copy,
 {
     fn default() -> Self {
         Self {
-            coefficients: vec![],
+            coefficients: [T::zero(); D],
         }
     }
 }
@@ -104,7 +104,7 @@ impl<T, const D: usize> PolyVec<T, D>
 where
     T: FiniteRing + Clone + Default,
 {
-    pub fn from_vec(coefficients: Vec<T>) -> Self {
+    pub fn from_vec(coefficients: [T;D]) -> Self {
         Self { coefficients }
     }
 }

--- a/src/polyvec/structures.rs
+++ b/src/polyvec/structures.rs
@@ -8,7 +8,7 @@ pub trait FiniteGroup: Sized + Eq {
     fn is_zero(&self) -> bool;
 
     /// Returns the additive identity
-    fn zero(&self) -> Self;
+    fn zero() -> Self;
 
     /// Returns the additive inverse of the element
     fn neg(&self) -> Self;
@@ -26,7 +26,7 @@ pub trait FiniteRing: Sized + Eq {
     fn is_zero(&self) -> bool;
 
     /// Returns the additive identity
-    fn zero(&self) -> Self;
+    fn zero() -> Self;
 
     /// Returns the additive inverse of the element
     fn neg(&self) -> Self;
@@ -38,7 +38,7 @@ pub trait FiniteRing: Sized + Eq {
     fn sub(&self, other: &Self) -> Self;
 
     /// Returns the multiplicative identity
-    fn one(&self) -> Self;
+    fn one() -> Self;
 
     /// Defines the multiplication of two elements
     fn mul(&self, other: &Self) -> Self;
@@ -50,7 +50,7 @@ pub trait FiniteField: Sized + Eq {
     fn is_zero(&self) -> bool;
 
     /// Returns the additive identity
-    fn zero(&self) -> Self;
+    fn zero() -> Self;
 
     /// Returns the additive inverse of the element
     fn neg(&self) -> Self;
@@ -62,7 +62,7 @@ pub trait FiniteField: Sized + Eq {
     fn sub(&self, other: &Self) -> Self;
 
     /// Returns the multiplicative identity
-    fn one(&self) -> Self;
+    fn one() -> Self;
 
     /// Defines the multiplication of two elements
     fn mul(&self, other: &Self) -> Self;
@@ -83,7 +83,7 @@ pub trait VectorSpace<T: FiniteField> {
     fn is_zero(&self) -> bool;
 
     /// Returns the additive identity
-    fn zero(&self) -> Self;
+    fn zero() -> Self;
 
     /// Returns the additive inverse of the element
     fn neg(&self) -> Self;
@@ -98,13 +98,13 @@ pub trait VectorSpace<T: FiniteField> {
     fn dimension(&self) -> usize;
 
     /// Initialise vector type
-    fn init(dimension: usize) -> Self;
+    fn init() -> Self;
 
     /// Scalar multiplication
     fn mulf(&self, other: &T) -> Self;
 
     /// Basis vector
-    fn basis_vector(&self, position: usize) -> Self;
+    fn basis_vector(position: usize) -> Self;
 
     /// Set coefficient
     fn set(&mut self, position: usize, value: T);
@@ -122,7 +122,7 @@ pub trait RingModule<T: FiniteRing> {
     fn is_zero(&self) -> bool;
 
     /// Returns the additive identity
-    fn zero(&self) -> Self;
+    fn zero() -> Self;
 
     /// Returns the additive inverse of the element
     fn neg(&self) -> Self;
@@ -137,13 +137,13 @@ pub trait RingModule<T: FiniteRing> {
     fn dimension(&self) -> usize;
 
     /// Initialise vector type
-    fn init(dimension: usize) -> Self;
+    fn init() -> Self;
 
     /// Scalar multiplication
     fn mulf(&self, other: &T) -> Self;
 
     /// Basis vector
-    fn basis_vector(&self, position: usize) -> Self;
+    fn basis_vector(position: usize) -> Self;
 
     /// Set coefficient
     fn set(&mut self, position: usize, value: T);

--- a/src/polyvec/structures.rs
+++ b/src/polyvec/structures.rs
@@ -68,7 +68,7 @@ pub trait FiniteField: Sized + Eq {
     fn mul(&self, other: &Self) -> Self;
 
     /// Returns the dimension of the finite field
-    fn dimension(&self) -> usize;
+    fn dimension() -> usize;
 
     /// Returns the multiplicative inverse of the element
     fn inv(&self) -> Result<Self, String>;
@@ -95,7 +95,7 @@ pub trait VectorSpace<T: FiniteField> {
     fn sub(&self, other: &Self) -> Self;
 
     /// Returns the vector's dimension
-    fn dimension(&self) -> usize;
+    fn dimension() -> usize;
 
     /// Initialise vector type
     fn init() -> Self;
@@ -134,7 +134,7 @@ pub trait RingModule<T: FiniteRing> {
     fn sub(&self, other: &Self) -> Self;
 
     /// Returns the vector's dimension
-    fn dimension(&self) -> usize;
+    fn dimension() -> usize;
 
     /// Initialise vector type
     fn init() -> Self;

--- a/src/primefield.rs
+++ b/src/primefield.rs
@@ -221,7 +221,7 @@ impl Debug for PrimeField3329 {
 }
 
 impl FiniteField for PrimeField3329 {
-    fn dimension(&self) -> usize {
+    fn dimension() -> usize {
         1
     }
     fn is_zero(&self) -> bool {

--- a/src/primefield.rs
+++ b/src/primefield.rs
@@ -228,16 +228,16 @@ impl FiniteField for PrimeField3329 {
         self.val == 0
     }
 
-    fn zero(&self) -> Self {
+    fn zero() -> Self {
         Self { val: 0 }
     }
 
-    fn one(&self) -> Self {
+    fn one() -> Self {
         Self { val: 1 }
     }
 
     fn neg(&self) -> Self {
-        self.zero().sub(self)
+        Self::zero().sub(self)
     }
 
     fn add(&self, other: &Self) -> Self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,13 +8,13 @@ use crate::{hash, polyvec::structures::FiniteField, ByteArray, Poly3329, F3329};
 
 /// Receives as input a byte stream B=(b0; b1; b2;...) and computes the NTT-representation a' = a'_0 + a'_0X + ... + a'_n-1X^(n-1) in R_q of a in R_q
 /// Algorithm 1 p. 7
-pub fn parse<const N: usize>(bs: &ByteArray, n: usize, q: usize) -> Poly3329<N> {
+pub fn parse<const N: usize>(bs: &ByteArray, q: usize) -> Poly3329<N> {
     let mut i = 0;
     let mut j = 0;
 
-    let mut p = Poly3329::init(n);
+    let mut p = Poly3329::init();
 
-    while j < n {
+    while j < N {
         let d = (bs.data[i] as usize) + (bs.data[i + 1] as usize) << 8;
         if d < 19 * q {
             p[j] = F3329::from_int(d.try_into().unwrap());
@@ -30,7 +30,7 @@ pub fn parse<const N: usize>(bs: &ByteArray, n: usize, q: usize) -> Poly3329<N> 
 /// Algorithm 2 p. 8
 /// Takes as input an array of 64 eta bytes
 pub fn cbd<const N: usize>(bs: ByteArray, eta: usize) -> Poly3329<N> {
-    let mut p = Poly3329::init(256);
+    let mut p = Poly3329::init();
     for i in 0..256 {
         let mut a = 0;
         let mut b = 0;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use crate::{hash, polyvec::structures::FiniteField, ByteArray, Poly3329, F3329};
 
 /// Receives as input a byte stream B=(b0; b1; b2;...) and computes the NTT-representation a' = a'_0 + a'_0X + ... + a'_n-1X^(n-1) in R_q of a in R_q
 /// Algorithm 1 p. 7
-pub fn parse(bs: &ByteArray, n: usize, q: usize) -> Poly3329 {
+pub fn parse<const N: usize>(bs: &ByteArray, n: usize, q: usize) -> Poly3329<N> {
     let mut i = 0;
     let mut j = 0;
 
@@ -29,7 +29,7 @@ pub fn parse(bs: &ByteArray, n: usize, q: usize) -> Poly3329 {
 /// Centered Binomial Distribution
 /// Algorithm 2 p. 8
 /// Takes as input an array of 64 eta bytes
-pub fn cbd(bs: ByteArray, eta: usize) -> Poly3329 {
+pub fn cbd<const N: usize>(bs: ByteArray, eta: usize) -> Poly3329<N> {
     let mut p = Poly3329::init(256);
     for i in 0..256 {
         let mut a = 0;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,6 @@
 //! Utils
 //!
 //! Various utils functions defined for the KEM anf PKE algorithms
-
-use std::convert::TryInto;
-
 use crate::{hash, polyvec::structures::FiniteField, ByteArray, Poly3329, F3329};
 
 /// Receives as input a byte stream B=(b0; b1; b2;...) and computes the NTT-representation a' = a'_0 + a'_0X + ... + a'_n-1X^(n-1) in R_q of a in R_q
@@ -17,7 +14,7 @@ pub fn parse<const N: usize>(bs: &ByteArray, q: usize) -> Poly3329<N> {
     while j < N {
         let d = (bs.data[i] as usize) + (bs.data[i + 1] as usize) << 8;
         if d < 19 * q {
-            p[j] = F3329::from_int(d.try_into().unwrap());
+            p.set_coeff(j, F3329::from_int(d));
             j += 1;
         }
         i += 2;
@@ -44,7 +41,7 @@ pub fn cbd<const N: usize>(bs: ByteArray, eta: usize) -> Poly3329<N> {
             }
         }
         let (a_hat, b_hat) = (F3329::from_int(a), F3329::from_int(b));
-        p[i] = a_hat.sub(&b_hat);
+        p.set_coeff(i, a_hat.sub(&b_hat));
     }
 
     p

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ use kybe_rs;
 #[test]
 fn encode_decode_poly() {
     use kybe_rs::{decode_to_poly, encode_poly, Poly3329};
-    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
+    let original = Poly3329::from_vec([Default::default(); 256]);
     let encoded = encode_poly(original.clone(), 12);
     let decoded = decode_to_poly(encoded, 12);
     assert!(decoded == original);
@@ -12,7 +12,7 @@ fn encode_decode_poly() {
 #[test]
 fn compress_decompress_poly() {
     use kybe_rs::{compress_poly, decompress_poly, Poly3329};
-    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
+    let original = Poly3329::from_vec([Default::default(); 256]);
     let encoded = compress_poly(original.clone(), 12, 3329);
     let decoded = decompress_poly(encoded, 12, 3329);
     assert!(decoded == original);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ use kybe_rs;
 #[test]
 fn encode_decode_poly() {
     use kybe_rs::{decode_to_poly, encode_poly, Poly3329};
-    let original = Poly3329::from_vec(vec![Default::default(); 256], 256);
+    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
     let encoded = encode_poly(original.clone(), 12);
     let decoded = decode_to_poly(encoded, 12);
     assert!(decoded == original);
@@ -12,7 +12,7 @@ fn encode_decode_poly() {
 #[test]
 fn compress_decompress_poly() {
     use kybe_rs::{compress_poly, decompress_poly, Poly3329};
-    let original = Poly3329::from_vec(vec![Default::default(); 256], 256);
+    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
     let encoded = compress_poly(original.clone(), 12, 3329);
     let decoded = decompress_poly(encoded, 12, 3329);
     assert!(decoded == original);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ use kybe_rs;
 #[test]
 fn encode_decode_poly() {
     use kybe_rs::{decode_to_poly, encode_poly, Poly3329};
-    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
+    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
     let encoded = encode_poly(original.clone(), 12);
     let decoded = decode_to_poly(encoded, 12);
     assert!(decoded == original);
@@ -12,7 +12,7 @@ fn encode_decode_poly() {
 #[test]
 fn compress_decompress_poly() {
     use kybe_rs::{compress_poly, decompress_poly, Poly3329};
-    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256], 256);
+    let original = Poly3329::<256>::from_vec(vec![Default::default(); 256]);
     let encoded = compress_poly(original.clone(), 12, 3329);
     let decoded = decompress_poly(encoded, 12, 3329);
     assert!(decoded == original);


### PR DESCRIPTION
Move most of the structs in the code to const generics:

- Move `Polynomial`, `PolyVec` and `Matrix` ton const generics
- Move these struct from `Vec` to `Array` (`Matrix` is now an array of array)
- Remove `assert` and `assert_eq` checking dimensions now done at compile time
- Move `one`, `sero`, `init` methods from instance to the struct itself
- `Polynomial` `degree` is now `Option<usize>` instead of `i32`

Note: 
- [BREAKING CHANGE] Currently only works with `kyber512` params: Need a change of architecture to handle all case (to be done in next PR)
- Decoding a `ByteArray` requires size knowledge at compile time for the output type. Currently is supposed to be the correct one.